### PR TITLE
Merge opencog to singnet

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -184,6 +184,7 @@ PACKAGES_RUNTIME="
 		unixodbc \
 		odbc-postgresql \
 		postgresql-client \
+		netcat-openbsd \
 		"
 
 PACKAGES_DOC="

--- a/ocpkg
+++ b/ocpkg
@@ -1005,6 +1005,12 @@ ensure_UTF_installed(){
     fi
 }
 
+# In Ubuntu 18.04 some links are absent when build-essential and ccache
+# packages are installed by same apt-get command
+update_ccache_links() {
+  sudo update-ccache-symlinks
+}
+
 # Install cxxtest for python3 co
 install_cxxtest() {
   (cd /tmp/ && rm -rf cxxtest* master.tar.gz
@@ -1033,6 +1039,9 @@ else
     fi
     ensure_UTF_installed
 fi
+
+# Update ccache links
+update_ccache_links
 
 # Install latest cxxtest
 install_cxxtest

--- a/ocpkg
+++ b/ocpkg
@@ -113,6 +113,8 @@ PACKAGES_TOOLS="
 PACKAGES_FETCH="
 		python3-pip \
 		git \
+		curl \
+		wget \
 			"
 		#bzr-rewrite \
 
@@ -129,7 +131,6 @@ PACKAGES_BUILD=" build-essential \
 		libiberty-dev \
 		libicu-dev \
 		libbz2-dev \
-		cython3 \
 		python3-dev \
 		python3-zmq \
 		python3-simplejson \
@@ -716,6 +717,7 @@ wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/req
 # system instllation is made.
 # TODO: cleanup the requirements.txt file.
 sudo python3 -m pip install -U pip
+sudo python3 -m pip install -U cython
 sudo pip install -U $(awk '!/scipy/&&!/numpy/&&!/matplotlib/' requirements.txt)
 sudo apt-get install -y --no-install-recommends python3-matplotlib python3-numpy python3-scipy
 

--- a/ocpkg
+++ b/ocpkg
@@ -616,15 +616,16 @@ if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_ADMIN ; the
 fi
 }
 
-# Install cogutil
-install_cogutil(){
-MESSAGE="Installing cogutil...." ; message
+# Install given opencog github repo
+install_opencog_github_repo(){
+local REPO="$1"
+MESSAGE="Installing ${REPO}...." ; message
 cd /tmp/
 # cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz* cogutil-master
-wget https://github.com/opencog/cogutil/archive/master.tar.gz
+rm -rf master.tar.gz* ${REPO}-master
+wget https://github.com/opencog/${REPO}/archive/master.tar.gz
 tar -xvf master.tar.gz
-cd cogutil-master/
+cd ${REPO}-master/
 mkdir build
 cd build/
 cmake ..
@@ -632,8 +633,13 @@ make -j$(nproc)
 sudo make install
 sudo ldconfig
 cd /tmp/
-rm -rf master.tar.gz cogutil-master/
+rm -rf master.tar.gz ${REPO}-master/
 cd $CURRENT_DIR
+}
+
+# Install cogutil
+install_cogutil(){
+install_opencog_github_repo cogutil
 }
 
 # Install notebooks
@@ -881,62 +887,17 @@ MESSAGE="Finished installation" ; message
 
 # Install AtomSpace
 install_atomspace(){
-MESSAGE="Installing atomspace...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz* atomspace-master
-wget https://github.com/opencog/atomspace/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd atomspace-master/
-mkdir build
-cd build/
-cmake ..
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf master.tar.gz atomspace-master/
-cd $CURRENT_DIR
+install_opencog_github_repo atomspace
 }
 
 # Install OpenCog
 install_opencog(){
-MESSAGE="Installing opencog...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz* opencog-master
-wget https://github.com/opencog/opencog/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd opencog-master/
-mkdir build
-cd build/
-cmake ..
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf master.tar.gz opencog-master/
-cd $CURRENT_DIR
+install_opencog_github_repo opencog
 }
 
 # Install MOSES
 install_moses(){
-MESSAGE="Installing MOSES...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz*  moses-master
-wget https://github.com/opencog/moses/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd moses-master/
-mkdir build
-cd build
-cmake ..
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf master.tar.gz moses-master/
-cd $CURRENT_DIR
+install_opencog_github_repo moses
 }
 
 # Install Link-Grammar

--- a/ocpkg
+++ b/ocpkg
@@ -111,7 +111,7 @@ PACKAGES_TOOLS="
 		#testdrive \
 
 PACKAGES_FETCH="
-        python-pip \
+		python3-pip \
 		git \
 			"
 		#bzr-rewrite \
@@ -123,19 +123,17 @@ PACKAGES_ADMIN="
 		epiphany-browser \
 		"
 
-PACKAGES_BUILD="
-		build-essential \
+PACKAGES_BUILD=" build-essential \
 		cmake \
-		cxxtest \
 		rlwrap \
 		libiberty-dev \
 		libicu-dev \
 		libbz2-dev \
-		cython \
+		cython3 \
 		python3-dev \
 		python3-zmq \
-                python3-pip
 		python3-simplejson \
+		python3-setuptools \
 		python3-nose \
 		libboost-date-time-dev \
 		libboost-filesystem-dev \
@@ -149,7 +147,6 @@ PACKAGES_BUILD="
 		libzmq3-dev \
 		libtbb-dev \
 		binutils-dev \
-		unixodbc-dev \
 		libpq-dev\
 		uuid-dev \
 		libprotoc-dev \
@@ -174,6 +171,8 @@ PACKAGES_BUILD="
 		libgmp-dev \
 		libffi-dev \
 		libreadline-dev \
+		libcpprest \
+		libltdl-dev \
 		"
 		#liblua5.1-0-dev \
 		#libxmlrpc-c3-dev \
@@ -582,10 +581,11 @@ for REPO in $REPOSITORIES ; do
 done
 
 # Ros repository for opencog/opencog repo
-# TODO remove this when the reference os is changed to 16.04.
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-# sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B01FA116
-sudo apt-key adv --keyserver keyserver.ubuntu.com  --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+if [[ "$UBUNTU_VERSION" = "\"16.04\"" ]]; then
+  sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+  sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+fi
+
 sudo apt-get $QUIET --assume-yes update
 }
 
@@ -641,7 +641,7 @@ MESSAGE="Installing notebooks...." ; message
 
 #####INSTALLING pip3 AND jupyter notebook
 cd
-sudo apt-get install python3-pip
+sudo apt-get install -y --no-install-recommends python3-pip
 sudo python3 -m pip install --upgrade pip
 sudo python3 -m pip install ipython jupyter
 
@@ -715,14 +715,14 @@ wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/req
 # build occupies a lot of space blotting the docker image. Thus instead a
 # system instllation is made.
 # TODO: cleanup the requirements.txt file.
-sudo pip install -U pip
+sudo python3 -m pip install -U pip
 sudo pip install -U $(awk '!/scipy/&&!/numpy/&&!/matplotlib/' requirements.txt)
-sudo apt-get install -y python-matplotlib python-numpy python-scipy python
+sudo apt-get install -y --no-install-recommends python3-matplotlib python3-numpy python3-scipy
 
 # For sentiment analysis
 # TODO: update depending on https://github.com/opencog/opencog/issues/2285
 sudo pip install -U pyyaml nltk
-sudo python -m nltk.downloader -d /usr/local/share/nltk_data punkt averaged_perceptron_tagger
+sudo python3 -m nltk.downloader -d /usr/local/share/nltk_data punkt averaged_perceptron_tagger
 rm -f requirements.txt*
 cd $CURRENT_DIR
 }
@@ -969,35 +969,6 @@ rm -rf link-grammar-5.*/
 cd $CURRENT_DIR
 }
 
-# Installs cpprest that is needed by pattern-miner
-# https://github.com/Microsoft/cpprestsdk/wiki/How-to-build-for-Linux
-install_cpprest(){
-if [[ "$UBUNTU_VERSION" == "\"14.04\"" ]]; then
-    if [[ -f /usr/local/lib/libcpprest.so.2.9 ]]; then
-        MESSAGE="cpprest is already installed." ; message
-        return
-    fi
-    MESSAGE="Installing cpprest...." ; message
-    cd /tmp/
-    # cleaning up remnants from previous install failures, if any.
-    rm -rf v2.9.0.tar.gz* cpprestsdk-2.9.0
-    wget https://github.com/Microsoft/cpprestsdk/archive/v2.9.0.tar.gz
-    tar -xvf v2.9.0.tar.gz
-    cd cpprestsdk-2.9.0/Release
-    mkdir build.release
-    cd build.release
-    CXX=g++-4.8 cmake .. -DCMAKE_BUILD_TYPE=Release
-    make -j$(nproc)
-    sudo make install
-    sudo ldconfig
-    cd /tmp/
-    rm -rf v2.9.0.tar.gz* cpprestsdk-2.9.0
-    cd $CURRENT_DIR
-else
-    sudo apt-get install -y libcpprest
-fi
-}
-
 install_bdwgc(){
 MESSAGE="Installing latest bdwgc ...." ; message
 local _version=$(curl https://github.com/ivmai/bdwgc/releases/latest \
@@ -1019,7 +990,7 @@ rm -rf ${_dir_name}*
 
 install_guile(){
 if [[ "$UBUNTU_VERSION" = "\"18.04\"" ]]; then
-    sudo apt-get install -y guile-2.2-dev
+    sudo apt-get install -y --no-install-recommends guile-2.2-dev
 else
    install_bdwgc
     MESSAGE="Installing guile-$GUILEVERSION...." ; message
@@ -1027,7 +998,7 @@ else
     # Clean up remnants from previous install failures, if any.
     rm -rf guile-${GUILEVERSION}*
     # Install dependency for the build.
-    sudo apt-get install -y libunistring-dev
+    sudo apt-get install -y --no-install-recommends libunistring-dev
     wget https://ftp.gnu.org/gnu/guile/guile-$GUILEVERSION.tar.gz
     tar -xvf guile-$GUILEVERSION.tar.gz
     cd guile-$GUILEVERSION
@@ -1075,27 +1046,29 @@ ensure_UTF_installed(){
 # Install system dependencies
 install_dependencies() {
 MESSAGE="Installing OpenCog build dependencies...." ; message
-
-if [ "$UBUNTU_VERSION" == "\"14.04\"" ]; then
-    if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH ros-indigo-octomap; then
-     # commented out the message b/c it is displayed on ctrl + c
-     # MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
-      exit 1
-    fi
-elif [[ "$UBUNTU_VERSION" = "\"16.04\"" ]]; then
+if [[ "$UBUNTU_VERSION" = "\"16.04\"" ]]; then
     # Don't use liboctomap-dev as it isn't the latest
-    if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH ros-kinetic-octomap locales ; then
+    if ! sudo apt-get $QUIET --no-upgrade --assume-yes --no-install-recommends install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH ros-kinetic-octomap locales ; then
         exit 1
     fi
     ensure_UTF_installed
 else
-    if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH liboctomap-dev locales ; then
+    if ! sudo apt-get $QUIET --no-upgrade --assume-yes --no-install-recommends install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH liboctomap-dev locales ; then
         exit 1
     fi
     ensure_UTF_installed
 fi
 
-install_cpprest
+# Install latest cxxtest
+# TODO Remove on 19.04
+(cd /tmp/ ; wget 'http://archive.ubuntu.com/ubuntu/pool/universe/c/cxxtest/cxxtest_4.4+git171022-1_all.deb')
+sudo apt-get install -y --no-install-recommends /tmp/cxxtest*
+
+# Configure python alternative. The priority is soo high just to ensure that
+# python is always set.
+PYTHON_PATH=$(readlink -f /usr/bin/python3)
+#sudo update-alternatives --install /usr/bin/python python "$PYTHON_PATH" 1000
+
 # Install guile >2.2 also install bdwgc for language-learning
 install_guile
 }

--- a/ocpkg
+++ b/ocpkg
@@ -1346,8 +1346,8 @@ if [ "$SELF_NAME" == "$TOOL_NAME" ] ; then
     if [ $INSTALL_ATOMSPACE ] ; then install_atomspace ; fi
     if [ $INSTALL_NOTEBOOKS ] ; then install_notebooks ; fi
     if [ $INSTALL_OPENCOG ] ; then install_opencog ; fi
-    if [ $INSTALL_LINK_GRAMMAR ] ; then install_link_grammar 5.4.3 ; fi
-    if [ $INSTALL_JAVA_LINK_GRAMMAR ] ; then install_link_grammar 5.4.3 ; fi
+    if [ $INSTALL_LINK_GRAMMAR ] ; then install_link_grammar ; fi
+    if [ $INSTALL_JAVA_LINK_GRAMMAR ] ; then install_link_grammar ; fi
     if [ $INSTALL_MOSES ] ; then install_moses ; fi
     if [ $INSTALL_GUILE ] ; then install_bdwgc && install_guile ; fi
     if [ $BUILD_SOURCE ] ; then build_source ; fi

--- a/ocpkg
+++ b/ocpkg
@@ -1082,7 +1082,9 @@ PYTHON_PATH=$(readlink -f /usr/bin/python3)
 
 # Update or install python tools
 sudo python3 -m pip install -U pip
-sudo python3 -m pip install -U cython
+# See https://github.com/opencog/atomspace/issues/2213 for why ~=0.23.5 is
+# choosen.
+sudo python3 -m pip install -U cython~=0.23.5
 
 # Install guile >2.2 also install bdwgc for language-learning
 install_guile

--- a/ocpkg
+++ b/ocpkg
@@ -1348,7 +1348,7 @@ if [ "$SELF_NAME" == "$TOOL_NAME" ] ; then
     if [ $BUILD_SOURCE ] ; then build_source ; fi
     if [ $INSTALL_NOTEBOOKS ] ; then install_notebooks ; fi
     if [ $BUILD_EXAMPLES ] ; then build_examples ; fi
-    if [ $TEST_SOURCE ] ; then install_build && test_source ; fi
+    if [ $TEST_SOURCE ] ; then test_source ; fi
     if [ $INSTALL_BUILD ] ; then install_build ; fi
 exit 0
 fi

--- a/ocpkg
+++ b/ocpkg
@@ -1018,24 +1018,29 @@ rm -rf ${_dir_name}*
 }
 
 install_guile(){
-MESSAGE="Installing guile-$GUILEVERSION...." ; message
-cd /tmp/
-# Clean up remnants from previous install failures, if any.
-rm -rf guile-${GUILEVERSION}*
-# Install dependency for the build.
-sudo apt-get install -y libunistring-dev
-wget https://ftp.gnu.org/gnu/guile/guile-$GUILEVERSION.tar.gz
-tar -xvf guile-$GUILEVERSION.tar.gz
-cd guile-$GUILEVERSION
-mkdir build
-cd build
-../configure
-make -j$(nproc)
-sudo make install
-sudo mv  /usr/local/lib/libguile-2.2.so.1.3.0-gdb.scm /usr/share/gdb/auto-load/
-sudo ldconfig
-cd /tmp/
-rm -rf guile-${GUILEVERSION}*
+if [[ "$UBUNTU_VERSION" = "\"18.04\"" ]]; then
+    sudo apt-get install -y guile-2.2-dev
+else
+   install_bdwgc
+    MESSAGE="Installing guile-$GUILEVERSION...." ; message
+    cd /tmp/
+    # Clean up remnants from previous install failures, if any.
+    rm -rf guile-${GUILEVERSION}*
+    # Install dependency for the build.
+    sudo apt-get install -y libunistring-dev
+    wget https://ftp.gnu.org/gnu/guile/guile-$GUILEVERSION.tar.gz
+    tar -xvf guile-$GUILEVERSION.tar.gz
+    cd guile-$GUILEVERSION
+    mkdir build
+    cd build
+    ../configure
+    make -j$(nproc)
+    sudo make install
+    sudo mv  /usr/local/lib/libguile-2.2.so.1.3.0-gdb.scm /usr/share/gdb/auto-load/
+    sudo ldconfig
+    cd /tmp/
+    rm -rf guile-${GUILEVERSION}*
+fi
 }
 
 # Install ros-behavior-scripting
@@ -1092,7 +1097,7 @@ fi
 
 install_cpprest
 # Install guile >2.2 also install bdwgc for language-learning
-install_bdwgc && install_guile
+install_guile
 }
 
 # Download data
@@ -1349,7 +1354,7 @@ if [ "$SELF_NAME" == "$TOOL_NAME" ] ; then
     if [ $INSTALL_LINK_GRAMMAR ] ; then install_link_grammar ; fi
     if [ $INSTALL_JAVA_LINK_GRAMMAR ] ; then install_link_grammar ; fi
     if [ $INSTALL_MOSES ] ; then install_moses ; fi
-    if [ $INSTALL_GUILE ] ; then install_bdwgc && install_guile ; fi
+    if [ $INSTALL_GUILE ] ; then install_guile ; fi
     if [ $BUILD_SOURCE ] ; then build_source ; fi
     if [ $INSTALL_NOTEBOOKS ] ; then install_notebooks ; fi
     if [ $BUILD_EXAMPLES ] ; then build_examples ; fi

--- a/ocpkg
+++ b/ocpkg
@@ -136,6 +136,7 @@ PACKAGES_BUILD="
 		python3-zmq \
                 python3-pip
 		python3-simplejson \
+		python3-nose \
 		libboost-date-time-dev \
 		libboost-filesystem-dev \
 		libboost-math-dev \

--- a/ocpkg
+++ b/ocpkg
@@ -716,8 +716,6 @@ wget https://raw.githubusercontent.com/opencog/opencog/master/opencog/python/req
 # build occupies a lot of space blotting the docker image. Thus instead a
 # system instllation is made.
 # TODO: cleanup the requirements.txt file.
-sudo python3 -m pip install -U pip
-sudo python3 -m pip install -U cython
 sudo pip install -U $(awk '!/scipy/&&!/numpy/&&!/matplotlib/' requirements.txt)
 sudo apt-get install -y --no-install-recommends python3-matplotlib python3-numpy python3-scipy
 
@@ -1045,6 +1043,19 @@ ensure_UTF_installed(){
     fi
 }
 
+# Install cxxtest for python3 co
+install_cxxtest() {
+  (cd /tmp/ && rm -rf cxxtest* master.tar.gz
+  sudo python3 -m pip install ply
+  wget https://github.com/CxxTest/cxxtest/archive/master.tar.gz
+  tar -xvf master.tar.gz
+  cd cxxtest-master/python/
+  sudo python3 setup.py -v install
+  cd ..
+  sudo install -m 644  cxxtest/* -D -t /usr/include/cxxtest
+  rm -rf cxxtest* master.tar.gz)
+}
+
 # Install system dependencies
 install_dependencies() {
 MESSAGE="Installing OpenCog build dependencies...." ; message
@@ -1062,14 +1073,16 @@ else
 fi
 
 # Install latest cxxtest
-# TODO Remove on 19.04
-(cd /tmp/ ; wget 'http://archive.ubuntu.com/ubuntu/pool/universe/c/cxxtest/cxxtest_4.4+git171022-1_all.deb')
-sudo apt-get install -y --no-install-recommends /tmp/cxxtest*
+install_cxxtest
 
 # Configure python alternative. The priority is soo high just to ensure that
 # python is always set.
 PYTHON_PATH=$(readlink -f /usr/bin/python3)
 #sudo update-alternatives --install /usr/bin/python python "$PYTHON_PATH" 1000
+
+# Update or install python tools
+sudo python3 -m pip install -U pip
+sudo python3 -m pip install -U cython
 
 # Install guile >2.2 also install bdwgc for language-learning
 install_guile


### PR DESCRIPTION
I don't use latest `opencog/master` by intention as python files are still at old locations in `singnet/atomspace`
And `opencog/atomspace` cannot be merged to `singnet/atomspace` because of https://github.com/opencog/atomspace/issues/2281