### PR TITLE
Ubuntu 20.04 overhaul

### DIFF
--- a/ocpkg
+++ b/ocpkg
@@ -860,6 +860,8 @@ install_opencog_github_repo moses
 # Install Link-Grammar
 install_link_grammar(){
 MESSAGE="Installing Link-Grammar...." ; message
+sudo sed -i 's,^\(MinProtocol[ ]*=\).*,\1'TLSv1.0',g' /etc/ssl/openssl.cnf
+sudo sed -i 's,^\(CipherString[ ]*=\).*,\1'DEFAULT@SECLEVEL=1',g' /etc/ssl/openssl.cnf
 cd /tmp/
 # cleaning up remnants from previous install failures, if any.
 rm -rf link-grammar-5.*/

--- a/ocpkg
+++ b/ocpkg
@@ -443,9 +443,6 @@ else
   done
 fi
 
-options = $(getopt -l "name:" "--name=opencog")
-eval set -- "$options"
-
 shift $((OPTIND - 1))
 
 message() {

--- a/ocpkg
+++ b/ocpkg
@@ -576,12 +576,6 @@ for REPO in $REPOSITORIES ; do
   sudo apt-add-repository -y $REPO
 done
 
-# Add cmake repository. See https://apt.kitware.com/ for details.
-if [[ "$UBUNTU_VERSION" = "\"18.04\"" ]]; then
-  wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
-  echo "deb https://apt.kitware.com/ubuntu/ bionic main" | sudo tee '/etc/apt/sources.list.d/cmake.list'
-fi
-
 sudo apt-get $QUIET --assume-yes update
 }
 
@@ -860,8 +854,11 @@ install_opencog_github_repo moses
 # Install Link-Grammar
 install_link_grammar(){
 MESSAGE="Installing Link-Grammar...." ; message
+
+MESSAGE="Setting TLS support to 1.0"; message
 sudo sed -i 's,^\(MinProtocol[ ]*=\).*,\1'TLSv1.0',g' /etc/ssl/openssl.cnf
 sudo sed -i 's,^\(CipherString[ ]*=\).*,\1'DEFAULT@SECLEVEL=1',g' /etc/ssl/openssl.cnf
+
 cd /tmp/
 # cleaning up remnants from previous install failures, if any.
 rm -rf link-grammar-5.*/
@@ -910,7 +907,7 @@ rm -rf ${_dir_name}*
 }
 
 install_guile(){
-if [[ "$UBUNTU_VERSION" = "\"18.04\"" ]]; then
+if [[ "$UBUNTU_VERSION" = "\"20.04\"" ]]; then
     sudo apt-get install -y --no-install-recommends guile-2.2-dev
 else
    install_bdwgc

--- a/ocpkg
+++ b/ocpkg
@@ -290,14 +290,13 @@ PACKAGES_EXDEV="
 		fakeroot \
 		gettext \
 		gdb \
-		g++-4.6 \
-		gcc-4.6 \
+		g++-10\
+		gcc-10 \
 		krb5-multidev \
 		libc6-dev \
 		libdpkg-perl \
 		libdpkg-perl \
 		libgcrypt11-dev \
-		libglade2-0 \
 		libgnutls-dev \
 		libgpg-error-dev \
 		libgssrpc4 \
@@ -310,7 +309,7 @@ PACKAGES_EXDEV="
 		libkrb5-dev \
 		libldap2-dev \
 		libltdl-dev \
-		libstdc++6-4.6-dev \
+		libstdc++-10-dev \
 		libtasn1-3-dev \
 		libtimedate-perl \
 		libtool \
@@ -320,13 +319,11 @@ PACKAGES_EXDEV="
 		manpages-dev \
 		m4 \
 		patch \
-		python-glade2 \
-		python-tk \
+		python3-tk \
 		tcl8.5 \
 		tk8.5 \
 		ttf-lyx \
 		zlib1g-dev \
-		python-bzrlib \
 		linux-headers-generic \
 		"
 
@@ -723,7 +720,7 @@ cd /tmp
 
 # For sentiment analysis
 # TODO: update depending on https://github.com/opencog/opencog/issues/2285
-sudo pip install -U pyyaml nltk Flask flask-restful flask-restful-swagger flask-cors
+sudo pip3 install -U pyyaml nltk Flask flask-restful flask-restful-swagger flask-cors
 sudo python3 -m nltk.downloader -d /usr/local/share/nltk_data punkt averaged_perceptron_tagger
 rm -f requirements.txt*
 cd $CURRENT_DIR
@@ -1004,8 +1001,8 @@ PYTHON_PATH=$(readlink -f /usr/bin/python3)
 # Update or install python tools
 sudo python3 -m pip install -U pip
 # See https://github.com/opencog/atomspace/issues/2213 for why ~=0.23.5 is
-# choosen.
-sudo python3 -m pip install -U cython~=0.23.5
+# chosen.
+sudo python3 -m pip install -U cython
 
 # Install guile >2.2 also install bdwgc for language-learning
 install_guile

--- a/ocpkg
+++ b/ocpkg
@@ -115,6 +115,7 @@ PACKAGES_FETCH="
 		git \
 		curl \
 		wget \
+    ca-certificates \
 			"
 		#bzr-rewrite \
 

--- a/ocpkg
+++ b/ocpkg
@@ -102,6 +102,10 @@ REPOSITORIES=""
 #       ppa:chris-lea/python-simplejson \
 #       ppa:gandelman-a/test-catalog \
 
+if [[ -z $GITHUB_NAME ]]; then
+  GITHUB_NAME="singnet"
+fi
+
 PACKAGES_TOOLS="
 		squashfs-tools \
 		genisoimage \
@@ -439,6 +443,9 @@ else
   done
 fi
 
+options = $(getopt -l "name:" "--name=opencog")
+eval set -- "$options"
+
 shift $((OPTIND - 1))
 
 message() {
@@ -626,18 +633,22 @@ install_admin() {
 # Install given opencog github repo
 install_opencog_github_repo() {
   local REPO="$1"
-  MESSAGE="Installing ${REPO}...."
+  MESSAGE="Installing ${REPO} from ${GITHUB_NAME}..."
   message
   cd /tmp/
   # cleaning up remnants from previous install failures, if any.
   rm -rf master.tar.gz* ${REPO}-master
-  wget https://github.com/ntoxeg/${REPO}/archive/master.tar.gz
+  wget https://github.com/${GITHUB_NAME}/${REPO}/archive/master.tar.gz
   tar -xvf master.tar.gz
   cd ${REPO}-master/
   mkdir build
   cd build/
   cmake ..
-  make -j$(nproc)
+  if ! $REPO == "ure"; then
+    make -j$(nproc)
+  else
+    make # for some reason URE compilation breaks with multiple jobs
+  fi
   sudo make install
   sudo ldconfig
   cd /tmp/

--- a/ocpkg
+++ b/ocpkg
@@ -641,7 +641,7 @@ install_opencog_github_repo() {
   mkdir build
   cd build/
   cmake ..
-  if ! $REPO == "ure"; then
+  if [ $REPO != "ure" ]; then
     make -j$(nproc)
   else
     make # for some reason URE compilation breaks with multiple jobs

--- a/ocpkg
+++ b/ocpkg
@@ -33,13 +33,13 @@ set -e
 
 declare -A PACKAGE_DESCRIPTION=(
   [local]="Local install with no packaging (default)"
-   [demo]="LiveCD  ISO image ~700MB with OpenCog Demo (auto-starting)"
-    [min]="LiveCD  ISO image ~700MB with OpenCog Server"
-    [dev]="LiveDVD ISO image ~900MB with OpenCog Developement Environment"
-    [kvm]="TBD Ubuntu KVM image with OpenCog Server"
- [demovm]="TBD Ubuntu VirtualBox image with OpenCog Unity3D proxy for demo"
-   [debs]="TBD Ubuntu packages (deb files)"
-   [docker]="TBD Docker Images"
+  [demo]="LiveCD  ISO image ~700MB with OpenCog Demo (auto-starting)"
+  [min]="LiveCD  ISO image ~700MB with OpenCog Server"
+  [dev]="LiveDVD ISO image ~900MB with OpenCog Developement Environment"
+  [kvm]="TBD Ubuntu KVM image with OpenCog Server"
+  [demovm]="TBD Ubuntu VirtualBox image with OpenCog Unity3D proxy for demo"
+  [debs]="TBD Ubuntu packages (deb files)"
+  [docker]="TBD Docker Images"
 )
 
 PATH_PREFIX=/usr/local
@@ -47,12 +47,12 @@ CURRENT_DIR=$(pwd)
 SOURCE_DIR=""
 BUILD_DIR=""
 
-if [ "$USER" == "root" ] ; then
- HOST_SOURCE_BRANCH=$PATH_PREFIX/src/opencog
- HOST_BUILD_DIR=/tmp/opencog_build
+if [ "$USER" == "root" ]; then
+  HOST_SOURCE_BRANCH=$PATH_PREFIX/src/opencog
+  HOST_BUILD_DIR=/tmp/opencog_build
 else
- HOST_SOURCE_BRANCH=$CURRENT_DIR/opencog/src
- HOST_BUILD_DIR=$CURRENT_DIR/opencog/build
+  HOST_SOURCE_BRANCH=$CURRENT_DIR/opencog/src
+  HOST_BUILD_DIR=$CURRENT_DIR/opencog/build
 fi
 
 SLEEP_TIME=0
@@ -79,7 +79,7 @@ TOOL_NAME=octool
 GUILEVERSION=2.2.3
 
 PROCESSORS=$(grep "^processor" /proc/cpuinfo | wc -l)
-MAKE_JOBS=$(($PROCESSORS+0))
+MAKE_JOBS=$(($PROCESSORS + 0))
 
 SQUASHFS_OPTIONS="-noDataCompression -noappend" #faster
 SQUASHFS_OPTIONS="-noappend"
@@ -87,7 +87,7 @@ SQUASHFS_OPTIONS="-noappend"
 LIVE_SOURCE_BRANCH=$HOST_SOURCE_BRANCH
 LIVE_BUILD_DIR=$HOST_BUILD_DIR
 
-VERBOSE="-v"				#for mount, umount, rm, etc.
+VERBOSE="-v" #for mount, umount, rm, etc.
 #QUIET="-qq" 				#for apt-get
 
 LIVE_DESKTOP_SOURCE="OpenCog Source Code"
@@ -106,9 +106,9 @@ PACKAGES_TOOLS="
 		squashfs-tools \
 		genisoimage \
 		"
-		#aria2 \
-		#qemu-kvm \
-		#testdrive \
+#aria2 \
+#qemu-kvm \
+#testdrive \
 
 PACKAGES_FETCH="
 		python3-pip \
@@ -117,7 +117,7 @@ PACKAGES_FETCH="
 		wget \
     ca-certificates \
 			"
-		#bzr-rewrite \
+#bzr-rewrite \
 
 PACKAGES_ADMIN="
 		apt-rdepends \
@@ -175,10 +175,10 @@ PACKAGES_BUILD=" build-essential \
 		libcpprest \
 		libltdl-dev \
 		"
-		#liblua5.1-0-dev \
-		#libxmlrpc-c3-dev \
-		#python-flask \
-		#python-flask-restful \
+#liblua5.1-0-dev \
+#libxmlrpc-c3-dev \
+#python-flask \
+#python-flask-restful \
 
 PACKAGES_RUNTIME="
 		unixodbc \
@@ -254,34 +254,34 @@ PACKAGES_REMOVE="
 		brltty \
 		liblouis-data \
 		"
-		#ubuntu-wallpapers \
-		#this stuff is for Unity 2D, but Ubuntu fails to login without it
-		#libqtgui4 \
-		#libqt4-core \
-		#libqt4-xmlpatterns \
-		#libwebkitgtk-3.0-0 \
-		#language-pack-pt-base \
-		#language-pack-es-base \
-		#language-pack-xh-base \
-		#language-pack-zh-hans \
-		#language-pack-de-base \
-		#language-pack-fr-base \
-		#language-pack-ca-base \
-		#language-pack-el-base \
-		#language-pack-sv-base \
-		#language-pack-ru-base \
-		#language-pack-gnome-zh-hans-base \
-		#language-pack-kde-zh-hans-base \
-		# NOTES
-		# apps listed first, then libraries that they depend upon which will
-		#	also uninstall other stuff
-		#	ubiquity - graphical Ubuntu installer that runs on boot
-		#  23MB app-install-data (ubuntu software center)
-		#  22MB ubuntu-docs (desktop docs)
-		#  44MB thunderbird
-		#  26MB amarok
-		# 200MB libreoffice
-		#  45MB smbclient
+#ubuntu-wallpapers \
+#this stuff is for Unity 2D, but Ubuntu fails to login without it
+#libqtgui4 \
+#libqt4-core \
+#libqt4-xmlpatterns \
+#libwebkitgtk-3.0-0 \
+#language-pack-pt-base \
+#language-pack-es-base \
+#language-pack-xh-base \
+#language-pack-zh-hans \
+#language-pack-de-base \
+#language-pack-fr-base \
+#language-pack-ca-base \
+#language-pack-el-base \
+#language-pack-sv-base \
+#language-pack-ru-base \
+#language-pack-gnome-zh-hans-base \
+#language-pack-kde-zh-hans-base \
+# NOTES
+# apps listed first, then libraries that they depend upon which will
+#	also uninstall other stuff
+#	ubiquity - graphical Ubuntu installer that runs on boot
+#  23MB app-install-data (ubuntu software center)
+#  22MB ubuntu-docs (desktop docs)
+#  44MB thunderbird
+#  26MB amarok
+# 200MB libreoffice
+#  45MB smbclient
 
 PACKAGES_EXDEV="
 		autoconf automake autotools-dev \
@@ -332,132 +332,141 @@ PACKAGES_EXDEV="
 # SECTION 2: Command line option handling
 
 usage() {
-if [ "$SELF_NAME" == "$TOOL_NAME" ] ; then
-  echo "Usage: $SELF_NAME OPTION"
-  echo " -r Add software repositories"
-  echo " -d Install base/system build dependencies"
-  echo " -p Install python build dependencies"
-  echo " -s Install haskell build dependencies in user space. Don't use sudo"
-  echo " -i Install build-job artifacts"
-  echo " -c Install Cogutil"
-  echo " -a Install AtomSpace"
-  echo " -f Install CogServer"
-  echo " -o Install OpenCog"
-  echo " -n Install notebook"
-  echo " -l {default|java} For installing Link Grammar with java binding '-l java' else '-l default'"
-  echo " -m Install MOSES"
-  echo " -g Install Guile $GUILEVERSION"
-  echo " -b Build source code in git worktree found @ $PWD"
-  echo " -e Build examples in git worktree found @ $PWD"
-  echo " -t Run tests of source code in git worktree found @ $PWD"
-  echo " -j [jobs] override number of auto-detected make jobs"
-  echo " -w download data for the opencog repo"
-  echo " -v Verbose output for 'apt-get' commands"
-  echo " -h This help message"
-else
-  echo "Usage: $SELF_NAME [OPTIONS] [PACKAGE-TYPE]"
-  echo "  PACKAGE-TYPES:"
-  for key in ${!PACKAGE_DESCRIPTION[@]}; do
-    echo "   " ${key} $'\t' "${PACKAGE_DESCRIPTION[$key]}"
-  done
-  echo "    (Live CD: Ubuntu ISO image ~700MB will be downloaded if none found.)"
-  echo "  OPTIONS:"
-  echo "    -i [filename]  ISO input  filename"
-  echo "    -o [filename]  ISO output filename"
-  echo "    -j [jobs]      override number of auto-detected make jobs"
-  echo "    -n             supress git updates"
-fi
+  if [ "$SELF_NAME" == "$TOOL_NAME" ]; then
+    echo "Usage: $SELF_NAME OPTION"
+    echo " -r Add software repositories"
+    echo " -d Install base/system build dependencies"
+    echo " -p Install python build dependencies"
+    echo " -s Install haskell build dependencies in user space. Don't use sudo"
+    echo " -i Install build-job artifacts"
+    echo " -c Install Cogutil"
+    echo " -a Install AtomSpace"
+    echo " -f Install CogServer"
+    echo " -o Install OpenCog"
+    echo " -n Install notebook"
+    echo " -l {default|java} For installing Link Grammar with java binding '-l java' else '-l default'"
+    echo " -m Install MOSES"
+    echo " -g Install Guile $GUILEVERSION"
+    echo " -b Build source code in git worktree found @ $PWD"
+    echo " -e Build examples in git worktree found @ $PWD"
+    echo " -t Run tests of source code in git worktree found @ $PWD"
+    echo " -j [jobs] override number of auto-detected make jobs"
+    echo " -w download data for the opencog repo"
+    echo " -v Verbose output for 'apt-get' commands"
+    echo " -h This help message"
+  else
+    echo "Usage: $SELF_NAME [OPTIONS] [PACKAGE-TYPE]"
+    echo "  PACKAGE-TYPES:"
+    for key in ${!PACKAGE_DESCRIPTION[@]}; do
+      echo "   " ${key} $'\t' "${PACKAGE_DESCRIPTION[$key]}"
+    done
+    echo "    (Live CD: Ubuntu ISO image ~700MB will be downloaded if none found.)"
+    echo "  OPTIONS:"
+    echo "    -i [filename]  ISO input  filename"
+    echo "    -o [filename]  ISO output filename"
+    echo "    -j [jobs]      override number of auto-detected make jobs"
+    echo "    -n             supress git updates"
+  fi
 }
-
 
 # TODO: change octool usage to 'octool project command' format. Where projects
 # are opencog, atomspace, cogutil... & commands are setup(for workspace),
 # package(for docker,deb, rpm). Each will have various options/sub-commands.
 #if [ $1 ] && [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
 
-if [ $# -eq 0 ] ; then NO_ARGS=true ; fi
+if [ $# -eq 0 ]; then NO_ARGS=true; fi
 
-if [ "$SELF_NAME" == "$TOOL_NAME" ] ; then
-  while getopts "abdegipcrstl:mhvj:own" flag ; do
+if [ "$SELF_NAME" == "$TOOL_NAME" ]; then
+  while getopts "abdegipcrstl:mhvj:own" flag; do
     case $flag in
-      r)	ADD_REPOSITORIES=true ;;
-      d)	INSTALL_DEPENDENCIES=true ;; #base development packages
-      w)	DOWNLOAD_DATA=true ;;
-      p)	INSTALL_OPENCOG_PYTHON_PACKAGES=true ;;
-      c)	INSTALL_COGUTIL=true ;;
-      a)	INSTALL_ATOMSPACE=true ;;
-      f)	INSTALL_COGSERVER=true ;;
-      o)	INSTALL_OPENCOG=true ;;
-      l)	if [ "$OPTARG" == "default" ]; then
-        	  INSTALL_LINK_GRAMMAR=true
-        	elif [ "$OPTARG" == "java" ]; then
-        	  INSTALL_JAVA_LINK_GRAMMAR=true
-        	else
-        	  MESSAGE="If you want java binding run '-l java' else '-l default'"
-        	  message ; exit 1
-        	fi ;;
-      m)	INSTALL_MOSES=true ;;
-      n)        INSTALL_NOTEBOOKS=true;;
-      g)	INSTALL_GUILE=true ;;
-      b)	BUILD_SOURCE=true ;;
-      e)	BUILD_EXAMPLES=true ;;
-      t)	TEST_SOURCE=true ;;
-      v)	unset QUIET ;;
-      j)	MAKE_JOBS="$OPTARG" ;;
-      s)    HASKELL_STACK_SETUP=true;;
-      i)    INSTALL_BUILD=true ;;
-      h)	usage ;;
-      \?)	usage; exit 1 ;;
-      *)  UNKNOWN_FLAGS=true ;;
+    r) ADD_REPOSITORIES=true ;;
+    d) INSTALL_DEPENDENCIES=true ;; #base development packages
+    w) DOWNLOAD_DATA=true ;;
+    p) INSTALL_OPENCOG_PYTHON_PACKAGES=true ;;
+    c) INSTALL_COGUTIL=true ;;
+    a) INSTALL_ATOMSPACE=true ;;
+    f) INSTALL_COGSERVER=true ;;
+    o) INSTALL_OPENCOG=true ;;
+    l) if [ "$OPTARG" == "default" ]; then
+      INSTALL_LINK_GRAMMAR=true
+    elif [ "$OPTARG" == "java" ]; then
+      INSTALL_JAVA_LINK_GRAMMAR=true
+    else
+      MESSAGE="If you want java binding run '-l java' else '-l default'"
+      message
+      exit 1
+    fi ;;
+    m) INSTALL_MOSES=true ;;
+    n) INSTALL_NOTEBOOKS=true ;;
+    g) INSTALL_GUILE=true ;;
+    b) BUILD_SOURCE=true ;;
+    e) BUILD_EXAMPLES=true ;;
+    t) TEST_SOURCE=true ;;
+    v) unset QUIET ;;
+    j) MAKE_JOBS="$OPTARG" ;;
+    s) HASKELL_STACK_SETUP=true ;;
+    i) INSTALL_BUILD=true ;;
+    h) usage ;;
+    \?)
+      usage
+      exit 1
+      ;;
+    *) UNKNOWN_FLAGS=true ;;
     esac
   done
 else
-  while getopts ":i:o:j:s:c:l:r:adubtnxrvh" flag ; do
+  while getopts ":i:o:j:s:c:l:r:adubtnxrvh" flag; do
     case $flag in
-      i)	INPUT_ISO_NAME="$OPTARG" ;;
-      o)	OUTPUT_ISO_NAME="$OPTARG" ;;
-      j)	MAKE_JOBS="$OPTARG" ;;			#override auto-detected MAKE_JOBS
-      s)	HOST_SOURCE_BRANCH="$OPTARG" ;;
-      c)	HOST_BUILD_DIR="$OPTARG" ;;		#local cached build dir
-      l)	LIVE_BUILD_DIR="$OPTARG" ;;		#live build directory
-      r)	BZR_REVISION="$OPTARG" ;;
-      a)	ADD_REPOSITORIES=true ;;
-      d)	INSTALL_DEPENDENCIES=true ;;		#ALL, none
-      u)	UPDATE_OPENCOG=true ;;			#git pull
-      b)	BUILD_OPENCOG=true ;;			#build opencog
-      t)	TEST_OPENCOG=true ;;                    #test opencog
-      n)	unset DEFAULT_UPDATE_OPENCOG ;;		#suppress git update
-      x)	unset DEFAULT_BUILD_OPENCOG ;;		#suppress build
-      p)	REINSTALL_PACKAGES=true ;;
-      v)	unset QUIET ;;
-      h)	usage ;;
-      \?)	usage ;;
-      *)  UNKNOWN_FLAGS=true ;;
+    i) INPUT_ISO_NAME="$OPTARG" ;;
+    o) OUTPUT_ISO_NAME="$OPTARG" ;;
+    j) MAKE_JOBS="$OPTARG" ;; #override auto-detected MAKE_JOBS
+    s) HOST_SOURCE_BRANCH="$OPTARG" ;;
+    c) HOST_BUILD_DIR="$OPTARG" ;; #local cached build dir
+    l) LIVE_BUILD_DIR="$OPTARG" ;; #live build directory
+    r) BZR_REVISION="$OPTARG" ;;
+    a) ADD_REPOSITORIES=true ;;
+    d) INSTALL_DEPENDENCIES=true ;;    #ALL, none
+    u) UPDATE_OPENCOG=true ;;          #git pull
+    b) BUILD_OPENCOG=true ;;           #build opencog
+    t) TEST_OPENCOG=true ;;            #test opencog
+    n) unset DEFAULT_UPDATE_OPENCOG ;; #suppress git update
+    x) unset DEFAULT_BUILD_OPENCOG ;;  #suppress build
+    p) REINSTALL_PACKAGES=true ;;
+    v) unset QUIET ;;
+    h) usage ;;
+    \?) usage ;;
+    *) UNKNOWN_FLAGS=true ;;
     esac
   done
 fi
 
-shift $((OPTIND-1))
+shift $((OPTIND - 1))
 
 message() {
-echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
+  echo -e "\e[1;34m[$SELF_NAME] $MESSAGE\e[0m"
 }
 
 PACKAGE_TYPE=$DEFAULT_PACKAGE_TYPE
 
 # This handles ./ocpkg runs, for e.g. `./ocpkg debs`
-if [ $1 ] && [ "$SELF_NAME" != "ocpkg" ] ; then
- case $1 in
-   debs)  PACKAGE_TYPE=$1 ;;
-   dev)   PACKAGE_TYPE=$1 ;;
-   demo)  PACKAGE_TYPE=$1 ;;
-   kvm)   PACKAGE_TYPE=$1 ;;
-   min)   PACKAGE_TYPE=$1 ;;
-   local) PACKAGE_TYPE=$1 ;;
-   docker) PACKAGE_TYPE=$1 ;;
-   *)	  MESSAGE="Package type not recognized."; message ; usage ; exit 1 ;;
- esac
- MESSAGE="Package type: $PACKAGE_TYPE : ${PACKAGE_DESCRIPTION[$PACKAGE_TYPE]}" ; message
+if [ $1 ] && [ "$SELF_NAME" != "ocpkg" ]; then
+  case $1 in
+  debs) PACKAGE_TYPE=$1 ;;
+  dev) PACKAGE_TYPE=$1 ;;
+  demo) PACKAGE_TYPE=$1 ;;
+  kvm) PACKAGE_TYPE=$1 ;;
+  min) PACKAGE_TYPE=$1 ;;
+  local) PACKAGE_TYPE=$1 ;;
+  docker) PACKAGE_TYPE=$1 ;;
+  *)
+    MESSAGE="Package type not recognized."
+    message
+    usage
+    exit 1
+    ;;
+  esac
+  MESSAGE="Package type: $PACKAGE_TYPE : ${PACKAGE_DESCRIPTION[$PACKAGE_TYPE]}"
+  message
 fi
 
 #echo "[otheropts]==> $@"
@@ -465,118 +474,127 @@ fi
 # SECTION 3: Error handling & cleanup
 
 debug() {
-MESSAGE="Dropping to debugging chroot prompt..." ; message
-chroot $LIVE_SQUASH_UNION /bin/bash -l
+  MESSAGE="Dropping to debugging chroot prompt..."
+  message
+  chroot $LIVE_SQUASH_UNION /bin/bash -l
 }
 
 cleanup_squash() {
-if [ -n "$LIVE_SQUASH_UNION" ]; then
-  MESSAGE="Cleaning up squash temp space..." ; message
-  fuser  $VERBOSE --mount $LIVE_SQUASH_UNION -kill
-  sleep  $SLEEP_TIME
-  umount $VERBOSE $LIVE_SQUASH_UNION/var/lib/apt/lists		|| true
-  umount $VERBOSE $LIVE_SQUASH_UNION/var/cache/apt/archives	|| true
-  umount $VERBOSE $LIVE_SQUASH_UNION/proc			|| true
-  umount $VERBOSE $LIVE_SQUASH_UNION/sys			|| true
-  umount $VERBOSE $LIVE_SQUASH_UNION/dev/pts			|| true
-  umount $VERBOSE $LIVE_SQUASH_UNION$LIVE_BUILD_DIR		|| true
-  umount $VERBOSE $LIVE_SQUASH_UNION$LIVE_SOURCE_BRANCH		|| true
-  MESSAGE="Killing processes..." ; message
-  fuser  $VERBOSE --mount $LIVE_SQUASH_UNION -kill
-  sleep  $SLEEP_TIME
-  umount -v -f $VERBOSE $LIVE_SQUASH_UNION			|| true
-  rmdir  $VERBOSE $LIVE_SQUASH_UNION				|| true
-fi
+  if [ -n "$LIVE_SQUASH_UNION" ]; then
+    MESSAGE="Cleaning up squash temp space..."
+    message
+    fuser $VERBOSE --mount $LIVE_SQUASH_UNION -kill
+    sleep $SLEEP_TIME
+    umount $VERBOSE $LIVE_SQUASH_UNION/var/lib/apt/lists || true
+    umount $VERBOSE $LIVE_SQUASH_UNION/var/cache/apt/archives || true
+    umount $VERBOSE $LIVE_SQUASH_UNION/proc || true
+    umount $VERBOSE $LIVE_SQUASH_UNION/sys || true
+    umount $VERBOSE $LIVE_SQUASH_UNION/dev/pts || true
+    umount $VERBOSE $LIVE_SQUASH_UNION$LIVE_BUILD_DIR || true
+    umount $VERBOSE $LIVE_SQUASH_UNION$LIVE_SOURCE_BRANCH || true
+    MESSAGE="Killing processes..."
+    message
+    fuser $VERBOSE --mount $LIVE_SQUASH_UNION -kill
+    sleep $SLEEP_TIME
+    umount -v -f $VERBOSE $LIVE_SQUASH_UNION || true
+    rmdir $VERBOSE $LIVE_SQUASH_UNION || true
+  fi
 
-if [ -n "$LIVE_SQUASH_DELTA" ]; then
-  echo " $LIVE_SQUASH_DELTA"
-  rm -rf $LIVE_SQUASH_DELTA					|| true
-fi
+  if [ -n "$LIVE_SQUASH_DELTA" ]; then
+    echo " $LIVE_SQUASH_DELTA"
+    rm -rf $LIVE_SQUASH_DELTA || true
+  fi
 
-if [ -n "$UBUNTU_SQUASH_FILES" ]; then
-  echo " $UBUNTU_SQUASH_FILES"
-  umount $VERBOSE $UBUNTU_SQUASH_FILES				|| true
-  rmdir  $VERBOSE $UBUNTU_SQUASH_FILES				|| true
-fi
+  if [ -n "$UBUNTU_SQUASH_FILES" ]; then
+    echo " $UBUNTU_SQUASH_FILES"
+    umount $VERBOSE $UBUNTU_SQUASH_FILES || true
+    rmdir $VERBOSE $UBUNTU_SQUASH_FILES || true
+  fi
 }
 
 cleanup_iso() {
-if [ -n       "$LIVE_ISO_UNION" ] ; then
-  MESSAGE="Cleaning up ISO temp space..." ; message
-  echo " $LIVE_ISO_UNION"
-  umount $VERBOSE $LIVE_ISO_UNION				|| true
-  rmdir  $LIVE_ISO_UNION					|| true
-  df -m  $LIVE_ISO_UNION					|| true
-fi
+  if [ -n "$LIVE_ISO_UNION" ]; then
+    MESSAGE="Cleaning up ISO temp space..."
+    message
+    echo " $LIVE_ISO_UNION"
+    umount $VERBOSE $LIVE_ISO_UNION || true
+    rmdir $LIVE_ISO_UNION || true
+    df -m $LIVE_ISO_UNION || true
+  fi
 
-if [ -n       "$LIVE_ISO_DELTA" ] ; then
-  echo " $LIVE_ISO_DELTA"
-  rm -rf $LIVE_ISO_DELTA					|| true
-fi
+  if [ -n "$LIVE_ISO_DELTA" ]; then
+    echo " $LIVE_ISO_DELTA"
+    rm -rf $LIVE_ISO_DELTA || true
+  fi
 
-if [ -n "$UBUNTU_ISO_FILES" ] ; then
-  echo " $UBUNTU_ISO_FILES"
-  umount $VERBOSE $UBUNTU_ISO_FILES				|| true
-  rmdir  $UBUNTU_ISO_FILES					|| true
-  df -m  $UBUNTU_ISO_FILES					|| true
-fi
+  if [ -n "$UBUNTU_ISO_FILES" ]; then
+    echo " $UBUNTU_ISO_FILES"
+    umount $VERBOSE $UBUNTU_ISO_FILES || true
+    rmdir $UBUNTU_ISO_FILES || true
+    df -m $UBUNTU_ISO_FILES || true
+  fi
 }
 
 exit_trap() {
-if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
-  MESSAGE="Exiting $SELF_NAME normally..." ; message
-  cleanup_squash
-  cleanup_iso
-fi
+  if [ "$SELF_NAME" != "$TOOL_NAME" ]; then
+    MESSAGE="Exiting $SELF_NAME normally..."
+    message
+    cleanup_squash
+    cleanup_iso
+  fi
 }
 
 quit_trap() {
-if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
-  MESSAGE="Exiting $SELF_NAME by request..." ; message
-  cleanup_squash
-  cleanup_iso
-fi
+  if [ "$SELF_NAME" != "$TOOL_NAME" ]; then
+    MESSAGE="Exiting $SELF_NAME by request..."
+    message
+    cleanup_squash
+    cleanup_iso
+  fi
 }
 
 error_trap() {
-if [ "$SELF_NAME" != "$TOOL_NAME" ] ; then
-  MESSAGE="Error trapped while running $SELF_NAME." ; message
+  if [ "$SELF_NAME" != "$TOOL_NAME" ]; then
+    MESSAGE="Error trapped while running $SELF_NAME."
+    message
 
-  MESSAGE="Cleanup will run after debug." ; message
-  debug
-  cleanup_squash
-  cleanup_iso
-fi
+    MESSAGE="Cleanup will run after debug."
+    message
+    debug
+    cleanup_squash
+    cleanup_iso
+  fi
 }
 
 trap error_trap ERR
-trap exit_trap  EXIT
-trap quit_trap  INT HUP QUIT TERM
+trap exit_trap EXIT
+trap quit_trap INT HUP QUIT TERM
 
 # SECTION 4: Function Definitions
 
 is_x68_64() {
-ARCH=$(uname -m);
-if [ "$ARCH" == "x86_64" ]; then
-  return 0
-else
-  return 1
-fi
+  ARCH=$(uname -m)
+  if [ "$ARCH" == "x86_64" ]; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 get_distro_version() {
-  cat /etc/os-release | grep "^VERSION_ID="  | cut -d "=" -f 2
+  cat /etc/os-release | grep "^VERSION_ID=" | cut -d "=" -f 2
 }
 
 UBUNTU_VERSION=$(get_distro_version)
 
 add_repositories() {
-MESSAGE="Adding software repositories..." ; message
-for REPO in $REPOSITORIES ; do
-  sudo apt-add-repository -y $REPO
-done
+  MESSAGE="Adding software repositories..."
+  message
+  for REPO in $REPOSITORIES; do
+    sudo apt-add-repository -y $REPO
+  done
 
-sudo apt-get $QUIET --assume-yes update
+  sudo apt-get $QUIET --assume-yes update
 }
 
 get_github_latest_release() {
@@ -589,329 +607,344 @@ get_github_latest_release() {
   # reference to the previous release, a hacky annoying reminder. If the
   # file-name has no reference to the version then all will go well.
   # TODO: Handle failure gracefully.
-  local _version=$(curl https://github.com/"$_user"/"$_repo"/releases/latest \
-    | cut -d "\"" -f 2 | cut -d "/" -f 8)
+  local _version=$(curl https://github.com/"$_user"/"$_repo"/releases/latest |
+    cut -d "\"" -f 2 | cut -d "/" -f 8)
   echo $_user $_repo $_version
   rm -f $_file_name
   wget https://github.com/"$_user"/"$_repo"/releases/download/"$_version"/"$_file_name"
 }
 
 install_admin() {
-MESSAGE="Installing sysadmin tools...." ; message
-if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_ADMIN ; then
-  MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
-  exit 1
-fi
+  MESSAGE="Installing sysadmin tools...."
+  message
+  if ! sudo apt-get $QUIET --no-upgrade --assume-yes install $PACKAGES_ADMIN; then
+    MESSAGE="Please enable 'universe' repositories and re-run this script."
+    message
+    exit 1
+  fi
 }
 
 # Install given opencog github repo
-install_opencog_github_repo(){
-local REPO="$1"
-MESSAGE="Installing ${REPO}...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz* ${REPO}-master
-wget https://github.com/singnet/${REPO}/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd ${REPO}-master/
-mkdir build
-cd build/
-cmake ..
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf master.tar.gz ${REPO}-master/
-cd $CURRENT_DIR
+install_opencog_github_repo() {
+  local REPO="$1"
+  MESSAGE="Installing ${REPO}...."
+  message
+  cd /tmp/
+  # cleaning up remnants from previous install failures, if any.
+  rm -rf master.tar.gz* ${REPO}-master
+  wget https://github.com/singnet/${REPO}/archive/master.tar.gz
+  tar -xvf master.tar.gz
+  cd ${REPO}-master/
+  mkdir build
+  cd build/
+  cmake ..
+  make -j$(nproc)
+  sudo make install
+  sudo ldconfig
+  cd /tmp/
+  rm -rf master.tar.gz ${REPO}-master/
+  cd $CURRENT_DIR
 }
 
 # Install cogutil
-install_cogutil(){
-install_opencog_github_repo cogutil
+install_cogutil() {
+  install_opencog_github_repo cogutil
 }
 
 # Install notebooks
-install_notebooks(){
-MESSAGE="Installing notebooks...." ; message
+install_notebooks() {
+  MESSAGE="Installing notebooks...."
+  message
 
+  #####INSTALLING pip3 AND jupyter notebook
+  cd
+  sudo apt-get install -y --no-install-recommends python3-pip
+  sudo python3 -m pip install --upgrade pip
+  sudo python3 -m pip install ipython jupyter
 
-#####INSTALLING pip3 AND jupyter notebook
-cd
-sudo apt-get install -y --no-install-recommends python3-pip
-sudo python3 -m pip install --upgrade pip
-sudo python3 -m pip install ipython jupyter
-
-#####INSTALLING GUILE KERNEL#####
-#check if site folder exits
-if [ ! -d "/usr/local/share/guile/site" ]
-then
+  #####INSTALLING GUILE KERNEL#####
+  #check if site folder exits
+  if [ ! -d "/usr/local/share/guile/site" ]; then
     cd /usr/local/share/guile/
     sudo mkdir site
     cd
-fi
+  fi
 
-#Install ZeroMQ library
-##Clean up remenants of previous installations##
-rm -rf zeromq-4.2.1*
-wget https://github.com/zeromq/libzmq/releases/download/v4.2.1/zeromq-4.2.1.tar.gz
-tar xvf zeromq-4.2.1.tar.gz
-cd zeromq-4.2.1/
-./configure
-make
-sudo make install
-cd
+  #Install ZeroMQ library
+  ##Clean up remenants of previous installations##
+  rm -rf zeromq-4.2.1*
+  wget https://github.com/zeromq/libzmq/releases/download/v4.2.1/zeromq-4.2.1.tar.gz
+  tar xvf zeromq-4.2.1.tar.gz
+  cd zeromq-4.2.1/
+  ./configure
+  make
+  sudo make install
+  cd
 
-#Install guile-json library
-##Clean up remenants of previous installations##
-rm -rf guile-json-0.6.0*
-wget http://download.savannah.gnu.org/releases/guile-json/guile-json-0.6.0.tar.gz
-tar xvf guile-json-0.6.0.tar.gz
-cd guile-json-0.6.0
-./configure --prefix=/usr/local/
-make
-sudo make install
-cd
+  #Install guile-json library
+  ##Clean up remenants of previous installations##
+  rm -rf guile-json-0.6.0*
+  wget http://download.savannah.gnu.org/releases/guile-json/guile-json-0.6.0.tar.gz
+  tar xvf guile-json-0.6.0.tar.gz
+  cd guile-json-0.6.0
+  ./configure --prefix=/usr/local/
+  make
+  sudo make install
+  cd
 
-cd `guile -c "(display (%global-site-dir))"`
-#Place guile-simple-zmq library to the guile library folder
-sudo rm -rf simple-zmq.scm*
-sudo wget https://raw.githubusercontent.com/jerry40/guile-simple-zmq/master/src/simple-zmq.scm
-#edit simple-zmq.scm => set BUF-SIZE to 8192.
-sudo sed -i 's/(define BUF-SIZE.*)/(define BUF-SIZE 8192)/' simple-zmq.scm
-cd
+  cd $(guile -c "(display (%global-site-dir))")
+  #Place guile-simple-zmq library to the guile library folder
+  sudo rm -rf simple-zmq.scm*
+  sudo wget https://raw.githubusercontent.com/jerry40/guile-simple-zmq/master/src/simple-zmq.scm
+  #edit simple-zmq.scm => set BUF-SIZE to 8192.
+  sudo sed -i 's/(define BUF-SIZE.*)/(define BUF-SIZE 8192)/' simple-zmq.scm
+  cd
 
-#Kernel setup
-if [ ! -d "/home/$USER/.local/share/jupyter/kernels/guile" ]
-then
+  #Kernel setup
+  if [ ! -d "/home/$USER/.local/share/jupyter/kernels/guile" ]; then
     sudo mkdir /home/$USER/.local/share/jupyter/kernels/guile
-fi
+  fi
 
-cd /home/$USER/.local/share/jupyter/kernels/guile
-sudo rm -rf guile-jupyter-kernel.scm hmac.scm kernel.json tools.scm
-sudo wget https://github.com/jerry40/guile-kernel/raw/master/src/guile-jupyter-kernel.scm
-sudo wget https://github.com/jerry40/guile-kernel/raw/master/src/hmac.scm
-sudo wget https://github.com/jerry40/guile-kernel/raw/master/src/kernel.json
-sudo wget https://github.com/jerry40/guile-kernel/raw/master/src/tools.scm
-sudo sed -i 's,\/home.*local,'$HOME/.local',' kernel.json
+  cd /home/$USER/.local/share/jupyter/kernels/guile
+  sudo rm -rf guile-jupyter-kernel.scm hmac.scm kernel.json tools.scm
+  sudo wget https://github.com/jerry40/guile-kernel/raw/master/src/guile-jupyter-kernel.scm
+  sudo wget https://github.com/jerry40/guile-kernel/raw/master/src/hmac.scm
+  sudo wget https://github.com/jerry40/guile-kernel/raw/master/src/kernel.json
+  sudo wget https://github.com/jerry40/guile-kernel/raw/master/src/tools.scm
+  sudo sed -i 's,\/home.*local,'$HOME/.local',' kernel.json
 
-echo "export PATH=$PATH:/home/$USER/.local/bin" >> /home/$USER/.bashrc
-echo "source $HOME/.bashrc"
-cd $CURRENT_DIR
+  echo "export PATH=$PATH:/home/$USER/.local/bin" >>/home/$USER/.bashrc
+  echo "source $HOME/.bashrc"
+  cd $CURRENT_DIR
 }
 
 # Install Python Packages
-install_opencog_python_packages(){
-MESSAGE="Installing python packages...." ; message
-cd /tmp
-# cleaning up remnants from previous install failures, if any.
-#rm -f requirements.txt*
-#wget https://raw.githubusercontent.com/singnet/opencog/master/opencog/python/attic/requirements.txt
-# scipy, numpy & matplotlib if installed using python-pip will take a long time
-# as they have to be built before being installed. And the arrifacts of the
-# build occupies a lot of space blotting the docker image. Thus instead a
-# system instllation is made.
-# TODO: cleanup the requirements.txt file.
-#sudo pip install -U $(awk '!/scipy/&&!/numpy/&&!/matplotlib/' requirements.txt)
-#sudo apt-get install -y --no-install-recommends python3-matplotlib python3-numpy python3-scipy
+install_opencog_python_packages() {
+  MESSAGE="Installing python packages...."
+  message
+  cd /tmp
+  # cleaning up remnants from previous install failures, if any.
+  #rm -f requirements.txt*
+  #wget https://raw.githubusercontent.com/singnet/opencog/master/opencog/python/attic/requirements.txt
+  # scipy, numpy & matplotlib if installed using python-pip will take a long time
+  # as they have to be built before being installed. And the arrifacts of the
+  # build occupies a lot of space blotting the docker image. Thus instead a
+  # system instllation is made.
+  # TODO: cleanup the requirements.txt file.
+  #sudo pip install -U $(awk '!/scipy/&&!/numpy/&&!/matplotlib/' requirements.txt)
+  #sudo apt-get install -y --no-install-recommends python3-matplotlib python3-numpy python3-scipy
 
-# For sentiment analysis
-# TODO: update depending on https://github.com/opencog/opencog/issues/2285
-sudo python3 -m pip install -U pyyaml nltk Flask flask-restful flask-restful-swagger flask-cors
-sudo python3 -m nltk.downloader -d /usr/local/share/nltk_data punkt averaged_perceptron_tagger
-rm -f requirements.txt*
-cd $CURRENT_DIR
+  # For sentiment analysis
+  # TODO: update depending on https://github.com/opencog/opencog/issues/2285
+  sudo python3 -m pip install -U pyyaml nltk Flask flask-restful flask-restful-swagger flask-cors
+  sudo python3 -m nltk.downloader -d /usr/local/share/nltk_data punkt averaged_perceptron_tagger
+  rm -f requirements.txt*
+  cd $CURRENT_DIR
 }
 
 # Install Haskell Dependencies
-install_haskell_dependencies(){
-MESSAGE="Installing haskell dependencies in user space...." ; message
-sudo wget -qO- https://get.haskellstack.org/ | sh
+install_haskell_dependencies() {
+  MESSAGE="Installing haskell dependencies in user space...."
+  message
+  sudo wget -qO- https://get.haskellstack.org/ | sh
 
-cd /tmp
-rm -rf patchelf*
-wget "https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2"
-tar -jxf patchelf-0.9.tar.bz2
-rm patchelf-0.9.tar.bz2
-cd patchelf-0.9
-./configure
-sudo make install
-cd /tmp
-rm -rf patchelf-0.9
-cd $CURRENT_DIR
+  cd /tmp
+  rm -rf patchelf*
+  wget "https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2"
+  tar -jxf patchelf-0.9.tar.bz2
+  rm patchelf-0.9.tar.bz2
+  cd patchelf-0.9
+  ./configure
+  sudo make install
+  cd /tmp
+  rm -rf patchelf-0.9
+  cd $CURRENT_DIR
 }
 
 # The following sets the source & build directory for a project
 set_source_and_build_dir() {
-if [ "$(git rev-parse --is-inside-work-tree)" == true ] ; then
+  if [ "$(git rev-parse --is-inside-work-tree)" == true ]; then
     SOURCE_DIR=$(git rev-parse --show-toplevel)
-    MESSAGE="Source Directory is set to $SOURCE_DIR" ; message
+    MESSAGE="Source Directory is set to $SOURCE_DIR"
+    message
     if [ -d $SOURCE_DIR/build ]; then
-        BUILD_DIR=$SOURCE_DIR/build
-        MESSAGE="Build Directory is set to $SOURCE_DIR/build" ; message
+      BUILD_DIR=$SOURCE_DIR/build
+      MESSAGE="Build Directory is set to $SOURCE_DIR/build"
+      message
     else
-        mkdir $SOURCE_DIR/build
-        BUILD_DIR=$SOURCE_DIR/build
-        MESSAGE="Build Directory is set to $SOURCE_DIR/build" ; message
+      mkdir $SOURCE_DIR/build
+      BUILD_DIR=$SOURCE_DIR/build
+      MESSAGE="Build Directory is set to $SOURCE_DIR/build"
+      message
     fi
-else
+  else
     MESSAGE="Exiting $SELF_NAME as git worktree is not detected run inside \
-a git worktree" ; message
+a git worktree"
+    message
     exit 1
-fi
+  fi
 }
 
 # Build function for opencog, atomspace, moses & cogutil repos
 build_source() {
-set_source_and_build_dir
-if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+  set_source_and_build_dir
+  if [ -a $BUILD_DIR/CMakeCache.txt ]; then
     rm $BUILD_DIR/CMakeCache.txt
-    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
-fi
-MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
-#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
-cmake -B$BUILD_DIR -H$SOURCE_DIR
-MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS" ; message
-make -C $BUILD_DIR -j$MAKE_JOBS
-MESSAGE="Finished building source" ; message
+    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt"
+    message
+  fi
+  MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR"
+  message
+  #stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+  cmake -B$BUILD_DIR -H$SOURCE_DIR
+  MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS"
+  message
+  make -C $BUILD_DIR -j$MAKE_JOBS
+  MESSAGE="Finished building source"
+  message
 }
 
 # Build examples function for opencog, atomspace, moses & cogutil repos
 build_examples() {
-set_source_and_build_dir
-if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+  set_source_and_build_dir
+  if [ -a $BUILD_DIR/CMakeCache.txt ]; then
     rm $BUILD_DIR/CMakeCache.txt
-    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
-fi
-MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
-#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
-cmake -B$BUILD_DIR -H$SOURCE_DIR
-MESSAGE="make -C $BUILD_DIR  -j$MAKE_JOBS examples" ; message
-make -C $BUILD_DIR -j$MAKE_JOBS examples
-MESSAGE="Finished building examples" ; message
+    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt"
+    message
+  fi
+  MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR"
+  message
+  #stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+  cmake -B$BUILD_DIR -H$SOURCE_DIR
+  MESSAGE="make -C $BUILD_DIR  -j$MAKE_JOBS examples"
+  message
+  make -C $BUILD_DIR -j$MAKE_JOBS examples
+  MESSAGE="Finished building examples"
+  message
 }
 
 # Run tests function for opencog, atomspace, moses & cogutil repos
 test_source() {
-#check if gearman service is running, start it if not
-if (( $(ps -ef | grep -v grep | grep gearman-job-server | wc -l) > 0 ))
-then
-    MESSAGE="gearman-job-server is running!!!";message
-else
-sudo /etc/init.d/gearman-job-server start
-fi
-set_source_and_build_dir
-if [ -a $BUILD_DIR/CMakeCache.txt ]; then
+  #check if gearman service is running, start it if not
+  if (($(ps -ef | grep -v grep | grep gearman-job-server | wc -l) > 0)); then
+    MESSAGE="gearman-job-server is running!!!"
+    message
+  else
+    sudo /etc/init.d/gearman-job-server start
+  fi
+  set_source_and_build_dir
+  if [ -a $BUILD_DIR/CMakeCache.txt ]; then
     rm $BUILD_DIR/CMakeCache.txt
-    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt" ; message
-fi
-MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR" ; message
-#stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
-cmake -B$BUILD_DIR -H$SOURCE_DIR
-MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS test" ; message
-make -C $BUILD_DIR -j$MAKE_JOBS test #ARGS=-j$MAKE_JOBS
-MESSAGE="Finished building & running tests" ; message
+    MESSAGE="Removed cmake cache file: rm $BUILD_DIR/CMakeCache.txt"
+    message
+  fi
+  MESSAGE="cmake -B$BUILD_DIR -H$SOURCE_DIR"
+  message
+  #stackoverflow.com/questions/20610255/how-to-tell-cmake-where-to-put-build-files
+  cmake -B$BUILD_DIR -H$SOURCE_DIR
+  MESSAGE="make -C $BUILD_DIR -j$MAKE_JOBS test"
+  message
+  make -C $BUILD_DIR -j$MAKE_JOBS test #ARGS=-j$MAKE_JOBS
+  MESSAGE="Finished building & running tests"
+  message
 }
 
 # Install build job artifacts
 install_build() {
-set_source_and_build_dir
-MESSAGE="Starting installation" ; message
-cd $BUILD_DIR
-sudo make install
-sudo ldconfig
-cd $CURRENT_DIR
-MESSAGE="Finished installation" ; message
+  set_source_and_build_dir
+  MESSAGE="Starting installation"
+  message
+  cd $BUILD_DIR
+  sudo make install
+  sudo ldconfig
+  cd $CURRENT_DIR
+  MESSAGE="Finished installation"
+  message
 }
 
 # Install AtomSpace
-install_atomspace(){
-install_opencog_github_repo atomspace
-install_opencog_github_repo ure
+install_atomspace() {
+  install_opencog_github_repo atomspace
+  install_opencog_github_repo ure
 }
 
 # Install CogServer
-install_cogserver(){
-install_opencog_github_repo cogserver
+install_cogserver() {
+  install_opencog_github_repo cogserver
 }
 
 # Install OpenCog
-install_opencog(){
-install_opencog_github_repo miner
-install_opencog_github_repo learn
-install_opencog_github_repo cogserver
-install_opencog_github_repo attention
-install_opencog_github_repo spacetime
-install_opencog_github_repo pattern-index
-install_opencog_github_repo visualization
-install_opencog_github_repo opencog
+install_opencog() {
+  install_opencog_github_repo miner
+  install_opencog_github_repo learn
+  install_opencog_github_repo cogserver
+  install_opencog_github_repo attention
+  install_opencog_github_repo spacetime
+  install_opencog_github_repo pattern-index
+  install_opencog_github_repo visualization
+  install_opencog_github_repo opencog
 }
 
 # Install MOSES
-install_moses(){
-install_opencog_github_repo moses
+install_moses() {
+  install_opencog_github_repo moses
 }
 
 # Install Link-Grammar
-install_link_grammar(){
-MESSAGE="Installing Link-Grammar...." ; message
+install_link_grammar() {
+  MESSAGE="Installing Link-Grammar...."
+  message
 
-MESSAGE="Setting TLS support to 1.0"; message
-sudo sed -i 's,^\(MinProtocol[ ]*=\).*,\1'TLSv1.0',g' /etc/ssl/openssl.cnf
-sudo sed -i 's,^\(CipherString[ ]*=\).*,\1'DEFAULT@SECLEVEL=1',g' /etc/ssl/openssl.cnf
+  cd /tmp/
+  # cleaning up remnants from previous install failures, if any.
+  rm -rf link-grammar-5.*/
 
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf link-grammar-5.*/
-if [ $# -eq 1 ]; then
-  wget http://www.abisource.com/downloads/link-grammar/${1}/link-grammar-${1}.tar.gz
+  wget http://www.abisource.com/downloads/link-grammar/5.8.0/link-grammar-5.8.0.tar.gz
   tar -zxf link-grammar-5*.tar.gz
-else
-  wget -r --no-parent -nH --cut-dirs=2 \
-    http://www.abisource.com/downloads/link-grammar/current/
-  tar -zxf current/link-grammar-5*.tar.gz
-  rm -r current
-fi
-cd link-grammar-5.*/
-mkdir build
-cd build
-if [ $INSTALL_JAVA_LINK_GRAMMAR ]; then
-  ../configure
-else
-  ../configure --disable-java-bindings
-fi
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf link-grammar-5.*/
-cd $CURRENT_DIR
+
+  cd link-grammar-5.*/
+  mkdir build
+  cd build
+  if [ $INSTALL_JAVA_LINK_GRAMMAR ]; then
+    ../configure
+  else
+    ../configure --disable-java-bindings
+  fi
+  make -j$(nproc)
+  sudo make install
+  sudo ldconfig
+  cd /tmp/
+  rm -rf link-grammar-5.*/
+  cd $CURRENT_DIR
 }
 
-install_bdwgc(){
-MESSAGE="Installing latest bdwgc ...." ; message
-local _version=$(curl https://github.com/ivmai/bdwgc/releases/latest \
-    | cut -d "\"" -f 2 | cut -d "/" -f 8)
-local _dir_name="gc-${_version:1}"
-local _file_name="${_dir_name}.tar.gz"
-cd /tmp/
-rm -rf ${_dir_name}*
-get_github_latest_release ivmai bdwgc ${_file_name}
-tar -xvf ${_file_name}
-cd ${_dir_name}
-./configure
-make -j$(nproc)
-sudo make install
-sudo ldconfig
-cd /tmp/
-rm -rf ${_dir_name}*
+install_bdwgc() {
+  MESSAGE="Installing latest bdwgc ...."
+  message
+  local _version=$(curl https://github.com/ivmai/bdwgc/releases/latest |
+    cut -d "\"" -f 2 | cut -d "/" -f 8)
+  local _dir_name="gc-${_version:1}"
+  local _file_name="${_dir_name}.tar.gz"
+  cd /tmp/
+  rm -rf ${_dir_name}*
+  get_github_latest_release ivmai bdwgc ${_file_name}
+  tar -xvf ${_file_name}
+  cd ${_dir_name}
+  ./configure
+  make -j$(nproc)
+  sudo make install
+  sudo ldconfig
+  cd /tmp/
+  rm -rf ${_dir_name}*
 }
 
-install_guile(){
-if [[ "$UBUNTU_VERSION" = "\"20.04\"" ]]; then
+install_guile() {
+  if [[ "$UBUNTU_VERSION" = "\"20.04\"" ]]; then
     sudo apt-get install -y --no-install-recommends guile-2.2-dev
-else
-   install_bdwgc
-    MESSAGE="Installing guile-$GUILEVERSION...." ; message
+  else
+    install_bdwgc
+    MESSAGE="Installing guile-$GUILEVERSION...."
+    message
     cd /tmp/
     # Clean up remnants from previous install failures, if any.
     rm -rf guile-${GUILEVERSION}*
@@ -925,40 +958,40 @@ else
     ../configure
     make -j$(nproc)
     sudo make install
-    sudo mv  /usr/local/lib/libguile-2.2.so.1.3.0-gdb.scm /usr/share/gdb/auto-load/
+    sudo mv /usr/local/lib/libguile-2.2.so.1.3.0-gdb.scm /usr/share/gdb/auto-load/
     sudo ldconfig
     cd /tmp/
     rm -rf guile-${GUILEVERSION}*
-fi
+  fi
 }
 
 # Install ros-behavior-scripting
-install_rbs(){
-MESSAGE="Installing ros-behavior-scripting ...." ; message
-cd /tmp/
-# cleaning up remnants from previous install failures, if any.
-rm -rf master.tar.gz* ros-behavior-scripting-master
-wget https://github.com/opencog/ros-behavior-scripting/archive/master.tar.gz
-tar -xvf master.tar.gz
-cd ros-behavior-scripting-master/
-mkdir build
-cd build/
-cmake ..
-sudo make install
-cd /tmp/
-rm -rf master.tar.gz ros-behavior-scripting-master/
-cd $CURRENT_DIR
+install_rbs() {
+  MESSAGE="Installing ros-behavior-scripting ...."
+  message
+  cd /tmp/
+  # cleaning up remnants from previous install failures, if any.
+  rm -rf master.tar.gz* ros-behavior-scripting-master
+  wget https://github.com/opencog/ros-behavior-scripting/archive/master.tar.gz
+  tar -xvf master.tar.gz
+  cd ros-behavior-scripting-master/
+  mkdir build
+  cd build/
+  cmake ..
+  sudo make install
+  cd /tmp/
+  rm -rf master.tar.gz ros-behavior-scripting-master/
+  cd $CURRENT_DIR
 }
 
 # atomspace unit tests have UTF-8 test cases
-ensure_UTF_installed(){
-    if locale -a | grep -q en_US.utf8
-    then
-	echo UTF-8 locale enabled already
-    else
-        sudo sh -c 'echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen'
-        sudo locale-gen
-    fi
+ensure_UTF_installed() {
+  if locale -a | grep -q en_US.utf8; then
+    echo UTF-8 locale enabled already
+  else
+    sudo sh -c 'echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen'
+    sudo locale-gen
+  fi
 }
 
 # In Ubuntu 18.04 some links are absent when build-essential and ccache
@@ -969,50 +1002,54 @@ update_ccache_links() {
 
 # Install cxxtest for python3 co
 install_cxxtest() {
-  (cd /tmp/ && rm -rf cxxtest* master.tar.gz
-  sudo python3 -m pip install ply
-  wget https://github.com/CxxTest/cxxtest/archive/master.tar.gz
-  tar -xvf master.tar.gz
-  cd cxxtest-master/python/
-  sudo python3 setup.py -v install
-  cd ..
-  sudo install -m 644  cxxtest/* -D -t /usr/include/cxxtest
-  rm -rf cxxtest* master.tar.gz)
+  (
+    cd /tmp/ && rm -rf cxxtest* master.tar.gz
+    sudo python3 -m pip install ply
+    wget https://github.com/CxxTest/cxxtest/archive/master.tar.gz
+    tar -xvf master.tar.gz
+    cd cxxtest-master/python/
+    sudo python3 setup.py -v install
+    cd ..
+    sudo install -m 644 cxxtest/* -D -t /usr/include/cxxtest
+    rm -rf cxxtest* master.tar.gz
+  )
 }
 
 # Install system dependencies
 install_dependencies() {
-MESSAGE="Installing OpenCog build dependencies...." ; message
-if ! sudo apt-get $QUIET --no-upgrade --assume-yes --no-install-recommends install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH liboctomap-dev locales ; then
+  MESSAGE="Installing OpenCog build dependencies...."
+  message
+  if ! sudo apt-get $QUIET --no-upgrade --assume-yes --no-install-recommends install $PACKAGES_BUILD $PACKAGES_RUNTIME $PACKAGES_FETCH liboctomap-dev locales; then
     exit 1
-fi
-ensure_UTF_installed
+  fi
+  ensure_UTF_installed
 
-# Update ccache links
-update_ccache_links
+  # Update ccache links
+  update_ccache_links
 
-# Install latest cxxtest
-install_cxxtest
+  # Install latest cxxtest
+  install_cxxtest
 
-# Configure python alternative. The priority is soo high just to ensure that
-# python is always set.
-PYTHON_PATH=$(readlink -f /usr/bin/python3)
-#sudo update-alternatives --install /usr/bin/python python "$PYTHON_PATH" 1000
+  # Configure python alternative. The priority is soo high just to ensure that
+  # python is always set.
+  PYTHON_PATH=$(readlink -f /usr/bin/python3)
+  #sudo update-alternatives --install /usr/bin/python python "$PYTHON_PATH" 1000
 
-# Update or install python tools
-sudo python3 -m pip install -U pip
-# See https://github.com/opencog/atomspace/issues/2213 for why ~=0.23.5 is
-# chosen.
-sudo python3 -m pip install -U cython
+  # Update or install python tools
+  sudo python3 -m pip install -U pip
+  # See https://github.com/opencog/atomspace/issues/2213 for why ~=0.23.5 is
+  # chosen.
+  sudo python3 -m pip install -U cython
 
-# Install guile >2.2 also install bdwgc for language-learning
-install_guile
+  # Install guile >2.2 also install bdwgc for language-learning
+  install_guile
 }
 
 # Download data
 download_data() {
   DOWNLOAD_DIR="$HOME/.opencog/data"
-  MESSAGE="Downloading OpenCog's datasets to $DOWNLOAD_DIR ...." ; message
+  MESSAGE="Downloading OpenCog's datasets to $DOWNLOAD_DIR ...."
+  message
   if [ ! -d "$DOWNLOAD_DIR" ]; then
     mkdir -p "$DOWNLOAD_DIR"
   fi
@@ -1024,301 +1061,379 @@ download_data() {
 }
 
 update_opencog_source() {
-if sudo apt-get --no-upgrade --assume-yes $QUIET install $PACKAGES_FETCH ; then
-  echo -n
-else
-  MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
-exit 1
-fi
-OPENCOG_SOURCE_DIR=$LIVE_SOURCE_BRANCH
-mkdir -p $OPENCOG_SOURCE_DIR || true
-if [ ! "$(ls -A $OPENCOG_SOURCE_DIR/.git)" ]; then
-  MESSAGE="Fetching OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
-  git clone https://github.com/singnet/opencog $OPENCOG_SOURCE_DIR
-else
-  if [ $UPDATE_OPENCOG ] ; then
-    MESSAGE="Updating OpenCog source at $OPENCOG_SOURCE_DIR..." ; message
-    cd $OPENCOG_SOURCE_DIR
-    git pull
-    cd -
+  if sudo apt-get --no-upgrade --assume-yes $QUIET install $PACKAGES_FETCH; then
+    echo -n
+  else
+    MESSAGE="Please enable 'universe' repositories and re-run this script."
+    message
+    exit 1
   fi
-fi
+  OPENCOG_SOURCE_DIR=$LIVE_SOURCE_BRANCH
+  mkdir -p $OPENCOG_SOURCE_DIR || true
+  if [ ! "$(ls -A $OPENCOG_SOURCE_DIR/.git)" ]; then
+    MESSAGE="Fetching OpenCog source at $OPENCOG_SOURCE_DIR..."
+    message
+    git clone https://github.com/singnet/opencog $OPENCOG_SOURCE_DIR
+  else
+    if [ $UPDATE_OPENCOG ]; then
+      MESSAGE="Updating OpenCog source at $OPENCOG_SOURCE_DIR..."
+      message
+      cd $OPENCOG_SOURCE_DIR
+      git pull
+      cd -
+    fi
+  fi
 }
 
 build_opencog() {
-mkdir -p -v $LIVE_BUILD_DIR || true
-cd $LIVE_BUILD_DIR
-MESSAGE="cmake $LIVE_SOURCE_BRANCH" ; message
-cmake $LIVE_SOURCE_BRANCH
-MESSAGE="make -j$MAKE_JOBS" ; message
-make -j$MAKE_JOBS
+  mkdir -p -v $LIVE_BUILD_DIR || true
+  cd $LIVE_BUILD_DIR
+  MESSAGE="cmake $LIVE_SOURCE_BRANCH"
+  message
+  cmake $LIVE_SOURCE_BRANCH
+  MESSAGE="make -j$MAKE_JOBS"
+  message
+  make -j$MAKE_JOBS
 
-if [ $TEST_OPENCOG ] ; then
-  make test
-fi
+  if [ $TEST_OPENCOG ]; then
+    make test
+  fi
 
-case $PACKAGE_TYPE in
-  min)	MESSAGE="Installing OpenCog..." ; message
- 	make install; exit 0;;
-  demo)	MESSAGE="Installing OpenCog..." ; message
-  	make install; exit 0;;
-  dev)	exit 0;;
-esac
+  case $PACKAGE_TYPE in
+  min)
+    MESSAGE="Installing OpenCog..."
+    message
+    make install
+    exit 0
+    ;;
+  demo)
+    MESSAGE="Installing OpenCog..."
+    message
+    make install
+    exit 0
+    ;;
+  dev) exit 0 ;;
+  esac
 
 }
 
 locate_live_iso() {
-if [ $INPUT_ISO_NAME ]; then
-  MESSAGE="Using Ubuntu image specified at $INPUT_ISO_NAME" ; message
-  UBUNTU_ISO_IMAGE=$INPUT_ISO_NAME
-else
-  UBUNTU_LOCATIONS=$(locate --existing --basename "\\$UBUNTU_ISO" | grep $HOME)
-  for LOC in $UBUNTU_LOCATIONS ; do
-    MESSAGE="Ubuntu image found at $LOC. Checksumming, please wait..." ; message
-    LOC_MD5SUM=$(md5sum $LOC | awk '{print $1}')
-  if [ "$LOC_MD5SUM" == "$UBUNTU_MD5SUM" ] ; then
-    UBUNTU_ISO_IMAGE=$LOC
-    MESSAGE="Using image found at $UBUNTU_ISO_IMAGE." ; message
-    break
+  if [ $INPUT_ISO_NAME ]; then
+    MESSAGE="Using Ubuntu image specified at $INPUT_ISO_NAME"
+    message
+    UBUNTU_ISO_IMAGE=$INPUT_ISO_NAME
   else
-    MESSAGE="...checksum failed." ; message
+    UBUNTU_LOCATIONS=$(locate --existing --basename "\\$UBUNTU_ISO" | grep $HOME)
+    for LOC in $UBUNTU_LOCATIONS; do
+      MESSAGE="Ubuntu image found at $LOC. Checksumming, please wait..."
+      message
+      LOC_MD5SUM=$(md5sum $LOC | awk '{print $1}')
+      if [ "$LOC_MD5SUM" == "$UBUNTU_MD5SUM" ]; then
+        UBUNTU_ISO_IMAGE=$LOC
+        MESSAGE="Using image found at $UBUNTU_ISO_IMAGE."
+        message
+        break
+      else
+        MESSAGE="...checksum failed."
+        message
+      fi
+    done
   fi
-done
-fi
-if [ ! -f $UBUNTU_ISO_IMAGE ] ; then
- #aria2c --seed-time=0 ${UBUNTU_URL}${UBUNTU_ISO}.torrent
- UBUNTU_ISO_IMAGE=${UBUNTU_ISO}
-fi
+  if [ ! -f $UBUNTU_ISO_IMAGE ]; then
+    #aria2c --seed-time=0 ${UBUNTU_URL}${UBUNTU_ISO}.torrent
+    UBUNTU_ISO_IMAGE=${UBUNTU_ISO}
+  fi
 }
 
 remove_packages() {
-MESSAGE="$PACKAGE_TYPE install type: Removing unecessary packages..." ; message
-chroot $LIVE_SQUASH_UNION apt-get --no-upgrade --assume-yes $QUIET purge $PACKAGES_REMOVE --auto-remove
-chroot $LIVE_SQUASH_UNION apt-get --no-upgrade --assume-yes $QUIET autoremove
-# stupid stupid stupid hack
-chroot $LIVE_SQUASH_UNION service cups stop
+  MESSAGE="$PACKAGE_TYPE install type: Removing unecessary packages..."
+  message
+  chroot $LIVE_SQUASH_UNION apt-get --no-upgrade --assume-yes $QUIET purge $PACKAGES_REMOVE --auto-remove
+  chroot $LIVE_SQUASH_UNION apt-get --no-upgrade --assume-yes $QUIET autoremove
+  # stupid stupid stupid hack
+  chroot $LIVE_SQUASH_UNION service cups stop
 }
 
 reinstall_removed() {
-MESSAGE="Re-installing removed packages..." ; message
-apt-get --no-upgrade --assume-yes $QUIET install $PACKAGES_REMOVE
+  MESSAGE="Re-installing removed packages..."
+  message
+  apt-get --no-upgrade --assume-yes $QUIET install $PACKAGES_REMOVE
 }
 
 keep_source() {
-MESSAGE="$PACKAGE_TYPE install type: Keeping source code..." ; message
-chroot $LIVE_SQUASH_UNION chown -R 999 $LIVE_SOURCE_BRANCH $LIVE_BUILD_DIR || true
-chroot $LIVE_SQUASH_UNION mkdir -p /home/$LIVE_USERNAME/Desktop/ || true
-chroot $LIVE_SQUASH_UNION ln -s "$LIVE_SOURCE_BRANCH" "/home/$LIVE_USERNAME/Desktop/$LIVE_DESKTOP_SOURCE" || true
+  MESSAGE="$PACKAGE_TYPE install type: Keeping source code..."
+  message
+  chroot $LIVE_SQUASH_UNION chown -R 999 $LIVE_SOURCE_BRANCH $LIVE_BUILD_DIR || true
+  chroot $LIVE_SQUASH_UNION mkdir -p /home/$LIVE_USERNAME/Desktop/ || true
+  chroot $LIVE_SQUASH_UNION ln -s "$LIVE_SOURCE_BRANCH" "/home/$LIVE_USERNAME/Desktop/$LIVE_DESKTOP_SOURCE" || true
 }
 
 remove_source() {
-MESSASGE="$PACKAGE_TYPE install type: Removing source code..." ; message
-chroot $LIVE_SQUASH_UNION umount $VERBOSE $LIVE_SOURCE_BRANCH
+  MESSASGE="$PACKAGE_TYPE install type: Removing source code..."
+  message
+  chroot $LIVE_SQUASH_UNION umount $VERBOSE $LIVE_SOURCE_BRANCH
 }
 
 remove_build() {
-MESSAGE="$PACKAGE_TYPE install type: Removing build files..." ; message
-echo umount $VERBOSE $LIVE_SQUASH_UNION$LIVE_BUILD_DIR
-umount $VERBOSE $LIVE_SQUASH_UNION$LIVE_BUILD_DIR || true
-rm -rf $LIVE_SQUASH_UNION$LIVE_BUILD_DIR || true
+  MESSAGE="$PACKAGE_TYPE install type: Removing build files..."
+  message
+  echo umount $VERBOSE $LIVE_SQUASH_UNION$LIVE_BUILD_DIR
+  umount $VERBOSE $LIVE_SQUASH_UNION$LIVE_BUILD_DIR || true
+  rm -rf $LIVE_SQUASH_UNION$LIVE_BUILD_DIR || true
 }
 
 remove_dev_debs() {
-MESSAGE="$PACKAGE_TYPE install type: Removing development packages..." ; message
-chroot $LIVE_SQUASH_UNION apt-get --no-upgrade --assume-yes purge $PACKAGES_BUILD $PACKAGES_EXDEV --auto-remove
-chroot $LIVE_SQUASH_UNION apt-get $QUIET autoremove --assume-yes
+  MESSAGE="$PACKAGE_TYPE install type: Removing development packages..."
+  message
+  chroot $LIVE_SQUASH_UNION apt-get --no-upgrade --assume-yes purge $PACKAGES_BUILD $PACKAGES_EXDEV --auto-remove
+  chroot $LIVE_SQUASH_UNION apt-get $QUIET autoremove --assume-yes
 }
 
 remove_doc_debs() {
-MESSAGE="$PACKAGE_TYPE install type: Removing documentation packages..." ; message
-chroot $LIVE_SQUASH_UNION apt-get --no-upgrade --assume-yes purge $PACKAGES_DOC --auto-remove
-chroot $LIVE_SQUASH_UNION apt-get $QUIET autoremove --assume-yes
+  MESSAGE="$PACKAGE_TYPE install type: Removing documentation packages..."
+  message
+  chroot $LIVE_SQUASH_UNION apt-get --no-upgrade --assume-yes purge $PACKAGES_DOC --auto-remove
+  chroot $LIVE_SQUASH_UNION apt-get $QUIET autoremove --assume-yes
 }
 
 install_package_tools() {
-MESSAGE="Installing packaging tools..." ; message
-if sudo apt-get --no-upgrade --assume-yes $QUIET -y install $PACKAGES_TOOLS ; then
- echo -n
-else
- MESSAGE="Please enable 'universe' repositories and re-run this script."  ; message
- exit 1
-fi
+  MESSAGE="Installing packaging tools..."
+  message
+  if sudo apt-get --no-upgrade --assume-yes $QUIET -y install $PACKAGES_TOOLS; then
+    echo -n
+  else
+    MESSAGE="Please enable 'universe' repositories and re-run this script."
+    message
+    exit 1
+  fi
 }
 
 mount_live_iso() {
-MESSAGE="Mounting Ubuntu ISO image..." ; message
+  MESSAGE="Mounting Ubuntu ISO image..."
+  message
 
-UBUNTU_ISO_FILES=$(mktemp -d --suffix=.UBUNTU_ISO_FILES)
-mount $VERBOSE -o ro -o loop -t iso9660 $UBUNTU_ISO_IMAGE $UBUNTU_ISO_FILES
+  UBUNTU_ISO_FILES=$(mktemp -d --suffix=.UBUNTU_ISO_FILES)
+  mount $VERBOSE -o ro -o loop -t iso9660 $UBUNTU_ISO_IMAGE $UBUNTU_ISO_FILES
 
-MESSAGE="Mounting Ubuntu compressed filesystem..." ; message
+  MESSAGE="Mounting Ubuntu compressed filesystem..."
+  message
 
-UBUNTU_SQUASH_BLOB="$UBUNTU_ISO_FILES/casper/filesystem.squashfs"
+  UBUNTU_SQUASH_BLOB="$UBUNTU_ISO_FILES/casper/filesystem.squashfs"
 
-if ! [ -e "$UBUNTU_SQUASH_BLOB" ] ; then
-  MESSAGE="Could not find the Ubuntu squashfs at '$UBUNTU_SQUASH_BLOB'." ; message
-  umount $VERBOSE $UBUNTU_ISO_FILES || true
-  exit 1
-fi
+  if ! [ -e "$UBUNTU_SQUASH_BLOB" ]; then
+    MESSAGE="Could not find the Ubuntu squashfs at '$UBUNTU_SQUASH_BLOB'."
+    message
+    umount $VERBOSE $UBUNTU_ISO_FILES || true
+    exit 1
+  fi
 
-LIVE_ISO_DELTA=$(mktemp -d --suffix=.LIVE_ISO_DELTA)
-LIVE_ISO_UNION=$(mktemp -d --suffix=.LIVE_ISO_UNION)
-mount $VERBOSE -t overlayfs -o upperdir=$LIVE_ISO_DELTA,lowerdir=$UBUNTU_ISO_FILES none $LIVE_ISO_UNION
+  LIVE_ISO_DELTA=$(mktemp -d --suffix=.LIVE_ISO_DELTA)
+  LIVE_ISO_UNION=$(mktemp -d --suffix=.LIVE_ISO_UNION)
+  mount $VERBOSE -t overlayfs -o upperdir=$LIVE_ISO_DELTA,lowerdir=$UBUNTU_ISO_FILES none $LIVE_ISO_UNION
 
-#MESSAGE="Mounting read-only Ubuntu compressed filesystem..." ; message
+  #MESSAGE="Mounting read-only Ubuntu compressed filesystem..." ; message
 
-UBUNTU_SQUASH_FILES=$(mktemp -d --suffix=.UBUNTU_SQUASH_FILES)
-mount $VERBOSE -o loop -t squashfs $UBUNTU_SQUASH_BLOB $UBUNTU_SQUASH_FILES
+  UBUNTU_SQUASH_FILES=$(mktemp -d --suffix=.UBUNTU_SQUASH_FILES)
+  mount $VERBOSE -o loop -t squashfs $UBUNTU_SQUASH_BLOB $UBUNTU_SQUASH_FILES
 
-#MESSAGE="Creating temporary workplace for remastering new compressed files..." ; message
+  #MESSAGE="Creating temporary workplace for remastering new compressed files..." ; message
 
-LIVE_SQUASH_DELTA=$(mktemp -d --suffix=.LIVE_SQUASH_DELTA)
-LIVE_SQUASH_UNION=$(mktemp -d --suffix=.LIVE_SQUASH_UNION)
-mount $VERBOSE -t overlayfs -o upperdir=$LIVE_SQUASH_DELTA,lowerdir=$UBUNTU_SQUASH_FILES none $LIVE_SQUASH_UNION
-chmod +rx $LIVE_SQUASH_UNION
+  LIVE_SQUASH_DELTA=$(mktemp -d --suffix=.LIVE_SQUASH_DELTA)
+  LIVE_SQUASH_UNION=$(mktemp -d --suffix=.LIVE_SQUASH_UNION)
+  mount $VERBOSE -t overlayfs -o upperdir=$LIVE_SQUASH_DELTA,lowerdir=$UBUNTU_SQUASH_FILES none $LIVE_SQUASH_UNION
+  chmod +rx $LIVE_SQUASH_UNION
 
-MESSAGE="Setting up chroot environment..." ; message
+  MESSAGE="Setting up chroot environment..."
+  message
 
-DISTRIB_ID=$(awk '/DISTRIB_ID=/' $LIVE_SQUASH_UNION/etc/lsb-release | sed 's/DISTRIB_ID=//' | tr '[:upper:]' '[:lower:]')
-DISTRIB_CODENAME=$(awk '/DISTRIB_CODENAME=/' $LIVE_SQUASH_UNION/etc/lsb-release | sed 's/DISTRIB_CODENAME=//' | tr '[:upper:]' '[:lower:]')
-LIVE_USERNAME=$DISTRIB_ID
-LIVE_BUILD_DIR=/home/$LIVE_USERNAME/build
+  DISTRIB_ID=$(awk '/DISTRIB_ID=/' $LIVE_SQUASH_UNION/etc/lsb-release | sed 's/DISTRIB_ID=//' | tr '[:upper:]' '[:lower:]')
+  DISTRIB_CODENAME=$(awk '/DISTRIB_CODENAME=/' $LIVE_SQUASH_UNION/etc/lsb-release | sed 's/DISTRIB_CODENAME=//' | tr '[:upper:]' '[:lower:]')
+  LIVE_USERNAME=$DISTRIB_ID
+  LIVE_BUILD_DIR=/home/$LIVE_USERNAME/build
 
-cp $LIVE_SQUASH_UNION/etc/resolv.conf      $LIVE_SQUASH_UNION/etc/resolv.conf.bak || true
-cp $LIVE_SQUASH_UNION/etc/apt/sources.list $LIVE_SQUASH_UNION/etc/apt/sources.list.bak || true
-cp /etc/resolv.conf      $LIVE_SQUASH_UNION/etc
-cp /etc/apt/sources.list $LIVE_SQUASH_UNION/etc/apt
-if [ -f /etc/apt/apt.conf.d/01apt-cacher-ng-proxy ] ; then
- cp /etc/apt/apt.conf.d/01apt-cacher-ng-proxy  $LIVE_SQUASH_UNION/etc/apt/apt.conf.d/01apt-cacher-ng-proxy
-fi
+  cp $LIVE_SQUASH_UNION/etc/resolv.conf $LIVE_SQUASH_UNION/etc/resolv.conf.bak || true
+  cp $LIVE_SQUASH_UNION/etc/apt/sources.list $LIVE_SQUASH_UNION/etc/apt/sources.list.bak || true
+  cp /etc/resolv.conf $LIVE_SQUASH_UNION/etc
+  cp /etc/apt/sources.list $LIVE_SQUASH_UNION/etc/apt
+  if [ -f /etc/apt/apt.conf.d/01apt-cacher-ng-proxy ]; then
+    cp /etc/apt/apt.conf.d/01apt-cacher-ng-proxy $LIVE_SQUASH_UNION/etc/apt/apt.conf.d/01apt-cacher-ng-proxy
+  fi
 
-cp $0 $LIVE_SQUASH_UNION$PATH_PREFIX/bin/$SELF_NAME ; chmod ugo+rx $LIVE_SQUASH_UNION$PATH_PREFIX/bin/$SELF_NAME
-cd $LIVE_SQUASH_UNION$PATH_PREFIX/bin
-ln -s $SELF_NAME $TOOL_NAME
-cd $CURRENT_DIR
+  cp $0 $LIVE_SQUASH_UNION$PATH_PREFIX/bin/$SELF_NAME
+  chmod ugo+rx $LIVE_SQUASH_UNION$PATH_PREFIX/bin/$SELF_NAME
+  cd $LIVE_SQUASH_UNION$PATH_PREFIX/bin
+  ln -s $SELF_NAME $TOOL_NAME
+  cd $CURRENT_DIR
 
-MESSAGE="Mounting filesystems..." ; message
+  MESSAGE="Mounting filesystems..."
+  message
 
-chroot $LIVE_SQUASH_UNION mount $VERBOSE -t proc none /proc
-chroot $LIVE_SQUASH_UNION mount $VERBOSE -t sysfs none /sys
-chroot $LIVE_SQUASH_UNION mount $VERBOSE -t devpts none /dev/pts
+  chroot $LIVE_SQUASH_UNION mount $VERBOSE -t proc none /proc
+  chroot $LIVE_SQUASH_UNION mount $VERBOSE -t sysfs none /sys
+  chroot $LIVE_SQUASH_UNION mount $VERBOSE -t devpts none /dev/pts
 
-mkdir -p $LIVE_SQUASH_UNION/var/cache/apt/archives
-mkdir -p $LIVE_SQUASH_UNION/var/lib/apt/lists
-mkdir -p $HOST_SOURCE_BRANCH
-mkdir -p $LIVE_SQUASH_UNION/$LIVE_SOURCE_BRANCH
+  mkdir -p $LIVE_SQUASH_UNION/var/cache/apt/archives
+  mkdir -p $LIVE_SQUASH_UNION/var/lib/apt/lists
+  mkdir -p $HOST_SOURCE_BRANCH
+  mkdir -p $LIVE_SQUASH_UNION/$LIVE_SOURCE_BRANCH
 
-mount $VERBOSE -o bind /var/cache/apt/archives $LIVE_SQUASH_UNION/var/cache/apt/archives
-mount $VERBOSE -o bind /var/lib/apt/lists $LIVE_SQUASH_UNION/var/lib/apt/lists
-mount $VERBOSE -o bind $HOST_SOURCE_BRANCH $LIVE_SQUASH_UNION/$LIVE_SOURCE_BRANCH
+  mount $VERBOSE -o bind /var/cache/apt/archives $LIVE_SQUASH_UNION/var/cache/apt/archives
+  mount $VERBOSE -o bind /var/lib/apt/lists $LIVE_SQUASH_UNION/var/lib/apt/lists
+  mount $VERBOSE -o bind $HOST_SOURCE_BRANCH $LIVE_SQUASH_UNION/$LIVE_SOURCE_BRANCH
 }
 
 prepare_live_iso() {
 
-fuser  $VERBOSE --mount $LIVE_SQUASH_UNION -kill
-sleep  $SLEEP_TIME
-umount $VERBOSE $LIVE_SQUASH_UNION/proc || true
-umount $VERBOSE $LIVE_SQUASH_UNION/sys || true
-umount $VERBOSE $LIVE_SQUASH_UNION/dev/pts|| true
-umount $VERBOSE $LIVE_SQUASH_UNION/var/lib/apt/lists || true
-umount $VERBOSE $LIVE_SQUASH_UNION/var/cache/apt/archives || true
+  fuser $VERBOSE --mount $LIVE_SQUASH_UNION -kill
+  sleep $SLEEP_TIME
+  umount $VERBOSE $LIVE_SQUASH_UNION/proc || true
+  umount $VERBOSE $LIVE_SQUASH_UNION/sys || true
+  umount $VERBOSE $LIVE_SQUASH_UNION/dev/pts || true
+  umount $VERBOSE $LIVE_SQUASH_UNION/var/lib/apt/lists || true
+  umount $VERBOSE $LIVE_SQUASH_UNION/var/cache/apt/archives || true
 
-#replace original config files
-cp $LIVE_SQUASH_UNION/etc/resolv.conf.bak      $LIVE_SQUASH_UNION/etc/resolv.conf || true
-cp $LIVE_SQUASH_UNION/etc/apt/sources.list.bak $LIVE_SQUASH_UNION/etc/apt/sources.list || true
+  #replace original config files
+  cp $LIVE_SQUASH_UNION/etc/resolv.conf.bak $LIVE_SQUASH_UNION/etc/resolv.conf || true
+  cp $LIVE_SQUASH_UNION/etc/apt/sources.list.bak $LIVE_SQUASH_UNION/etc/apt/sources.list || true
 
-if [ -f  $LIVE_SQUASH_UNION/etc/apt/apt.conf.d/01apt-cacher-ng-proxy ]; then
-  rm $LIVE_SQUASH_UNION/etc/apt/apt.conf.d/01apt-cacher-ng-proxy
-fi
+  if [ -f $LIVE_SQUASH_UNION/etc/apt/apt.conf.d/01apt-cacher-ng-proxy ]; then
+    rm $LIVE_SQUASH_UNION/etc/apt/apt.conf.d/01apt-cacher-ng-proxy
+  fi
 }
 
 write_live_media() {
-MESSAGE="Creating new compressed filesystem..." ; message
-mksquashfs $LIVE_SQUASH_UNION $LIVE_ISO_UNION/casper/filesystem.squashfs $SQUASHFS_OPTIONS
-printf $(sudo du -sx --block-size=1 $LIVE_SQUASH_UNION | cut -f1) > $LIVE_ISO_UNION/casper/filesystem.size
-MESSAGE="Creating new bootable ISO image..." ; message
-mkisofs -D -r -V $OUTPUT_ISO_LOCATION/$OUTPUT_ISO_NAME -cache-inodes -J -l -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -o "$OUTPUT_ISO_LOCATION/$OUTPUT_ISO_NAME" $LIVE_ISO_UNION
-MESSAGE="Wrote $(du -sm $OUTPUT_ISO_LOCATION/$OUTPUT_ISO_NAME)MB ..." ; message
-chown $VERBOSE $SUDO_USER $OUTPUT_ISO_LOCATION/$OUTPUT_ISO_NAME
-cleanup_squash
-cleanup_iso
+  MESSAGE="Creating new compressed filesystem..."
+  message
+  mksquashfs $LIVE_SQUASH_UNION $LIVE_ISO_UNION/casper/filesystem.squashfs $SQUASHFS_OPTIONS
+  printf $(sudo du -sx --block-size=1 $LIVE_SQUASH_UNION | cut -f1) >$LIVE_ISO_UNION/casper/filesystem.size
+  MESSAGE="Creating new bootable ISO image..."
+  message
+  mkisofs -D -r -V $OUTPUT_ISO_LOCATION/$OUTPUT_ISO_NAME -cache-inodes -J -l -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -o "$OUTPUT_ISO_LOCATION/$OUTPUT_ISO_NAME" $LIVE_ISO_UNION
+  MESSAGE="Wrote $(du -sm $OUTPUT_ISO_LOCATION/$OUTPUT_ISO_NAME)MB ..."
+  message
+  chown $VERBOSE $SUDO_USER $OUTPUT_ISO_LOCATION/$OUTPUT_ISO_NAME
+  cleanup_squash
+  cleanup_iso
 }
 
 # SECTION 5: Main Program (MAIN main)
 
 # This is mainly for configuring workspaces depending on the type
 # of project being worked on. The order here matters.
-if [ "$SELF_NAME" == "$TOOL_NAME" ] ; then
-    if [ $UNKNOWN_FLAGS ] ; then usage; exit 1 ; fi
-    if [ $NO_ARGS ] ; then usage; exit 1 ; fi
-    if [ $ADD_REPOSITORIES ] ; then add_repositories ; fi
-    if [ $INSTALL_DEPENDENCIES ] ; then install_dependencies ; fi
-    if [ $DOWNLOAD_DATA ] ; then download_data ; fi
-    if [ $HASKELL_STACK_SETUP ] ; then install_haskell_dependencies ; fi
-    if [ $INSTALL_OPENCOG_PYTHON_PACKAGES ] ; then install_opencog_python_packages ; fi
-    if [ $INSTALL_COGUTIL ] ; then install_cogutil ; fi
-    if [ $INSTALL_ATOMSPACE ] ; then install_atomspace ; fi
-    if [ $INSTALL_COGSERVER ] ; then install_cogserver ; fi
-    if [ $INSTALL_NOTEBOOKS ] ; then install_notebooks ; fi
-    if [ $INSTALL_OPENCOG ] ; then install_opencog ; fi
-    if [ $INSTALL_LINK_GRAMMAR ] ; then install_link_grammar ; fi
-    if [ $INSTALL_JAVA_LINK_GRAMMAR ] ; then install_link_grammar ; fi
-    if [ $INSTALL_MOSES ] ; then install_moses ; fi
-    if [ $INSTALL_GUILE ] ; then install_guile ; fi
-    if [ $BUILD_SOURCE ] ; then build_source ; fi
-    if [ $INSTALL_NOTEBOOKS ] ; then install_notebooks ; fi
-    if [ $BUILD_EXAMPLES ] ; then build_examples ; fi
-    if [ $TEST_SOURCE ] ; then test_source ; fi
-    if [ $INSTALL_BUILD ] ; then install_build ; fi
-exit 0
+if [ "$SELF_NAME" == "$TOOL_NAME" ]; then
+  if [ $UNKNOWN_FLAGS ]; then
+    usage
+    exit 1
+  fi
+  if [ $NO_ARGS ]; then
+    usage
+    exit 1
+  fi
+  if [ $ADD_REPOSITORIES ]; then add_repositories; fi
+  if [ $INSTALL_DEPENDENCIES ]; then install_dependencies; fi
+  if [ $DOWNLOAD_DATA ]; then download_data; fi
+  if [ $HASKELL_STACK_SETUP ]; then install_haskell_dependencies; fi
+  if [ $INSTALL_OPENCOG_PYTHON_PACKAGES ]; then install_opencog_python_packages; fi
+  if [ $INSTALL_COGUTIL ]; then install_cogutil; fi
+  if [ $INSTALL_ATOMSPACE ]; then install_atomspace; fi
+  if [ $INSTALL_COGSERVER ]; then install_cogserver; fi
+  if [ $INSTALL_NOTEBOOKS ]; then install_notebooks; fi
+  if [ $INSTALL_OPENCOG ]; then install_opencog; fi
+  if [ $INSTALL_LINK_GRAMMAR ]; then install_link_grammar; fi
+  if [ $INSTALL_JAVA_LINK_GRAMMAR ]; then install_link_grammar; fi
+  if [ $INSTALL_MOSES ]; then install_moses; fi
+  if [ $INSTALL_GUILE ]; then install_guile; fi
+  if [ $BUILD_SOURCE ]; then build_source; fi
+  if [ $INSTALL_NOTEBOOKS ]; then install_notebooks; fi
+  if [ $BUILD_EXAMPLES ]; then build_examples; fi
+  if [ $TEST_SOURCE ]; then test_source; fi
+  if [ $INSTALL_BUILD ]; then install_build; fi
+  exit 0
 fi
 
 # option flag conditionals are finished, so set defaults
 
-if [ ! $ADD_REPOSITORIES ] ; then ADD_REPOSITORIES=$DEFAULT_ADD_REPOSITORIES; fi
-if [ ! $INSTALL_DEPENDENCIES ] ; then INSTALL_DEPENDENCIES=$DEFAULT_INSTALL_DEPENDENCIES; fi
-if [ ! $UPDATE_OPENCOG ] ; then UPDATE_OPENCOG=$DEFAULT_UPDATE_OPENCOG; fi
-if [ ! $BUILD_OPENCOG ] ; then BUILD_OPENCOG=$DEFAULT_BUILD_OPENCOG; fi
-if [ ! $TEST_OPENCOG ] ; then TEST_OPENCOG=$DEFAULT_TEST_OPENCOG; fi
+if [ ! $ADD_REPOSITORIES ]; then ADD_REPOSITORIES=$DEFAULT_ADD_REPOSITORIES; fi
+if [ ! $INSTALL_DEPENDENCIES ]; then INSTALL_DEPENDENCIES=$DEFAULT_INSTALL_DEPENDENCIES; fi
+if [ ! $UPDATE_OPENCOG ]; then UPDATE_OPENCOG=$DEFAULT_UPDATE_OPENCOG; fi
+if [ ! $BUILD_OPENCOG ]; then BUILD_OPENCOG=$DEFAULT_BUILD_OPENCOG; fi
+if [ ! $TEST_OPENCOG ]; then TEST_OPENCOG=$DEFAULT_TEST_OPENCOG; fi
 
 # package type selected when invoked as 'ocpkg'
 
 case $PACKAGE_TYPE in
-  demo)	install_package_tools; locate_live_iso ; mount_live_iso ; remove_packages ;;
-  min)	install_package_tools; locate_live_iso ; mount_live_iso ; remove_packages ;;
-  dev)	install_package_tools; locate_live_iso ; mount_live_iso
-      	MESSAGE="$PACKAGE_TYPE install type: Keeping all Ubuntu packages..." ; message ;;
+demo)
+  install_package_tools
+  locate_live_iso
+  mount_live_iso
+  remove_packages
+  ;;
+min)
+  install_package_tools
+  locate_live_iso
+  mount_live_iso
+  remove_packages
+  ;;
+dev)
+  install_package_tools
+  locate_live_iso
+  mount_live_iso
+  MESSAGE="$PACKAGE_TYPE install type: Keeping all Ubuntu packages..."
+  message
+  ;;
 esac
 
 case $PACKAGE_TYPE in
-  local) add_repositories ; install_dependencies ;;
-  demo)  chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -a -d ;;
-  min)   chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -a -d ;;
-  dev)   chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -a -d ;;
+local)
+  add_repositories
+  install_dependencies
+  ;;
+demo) chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -a -d ;;
+min) chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -a -d ;;
+dev) chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -a -d ;;
 esac
 
 case $PACKAGE_TYPE in
-  local) if [ $UPDATE_OPENCOG ] ; then update_opencog_source ; fi ;;
-  demo)  if [ $UPDATE_OPENCOG ] ; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -u ; fi ;;
-  min)   if [ $UPDATE_OPENCOG ] ; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -u ; fi ;;
-  dev)   if [ $UPDATE_OPENCOG ] ; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -u ; fi ;;
+local) if [ $UPDATE_OPENCOG ]; then update_opencog_source; fi ;;
+demo) if [ $UPDATE_OPENCOG ]; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -u; fi ;;
+min) if [ $UPDATE_OPENCOG ]; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -u; fi ;;
+dev) if [ $UPDATE_OPENCOG ]; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -u; fi ;;
 esac
 
 case $PACKAGE_TYPE in
-  local) if [ $BUILD_OPENCOG ] ; then build_opencog ; fi ;;
-  demo)  if [ $BUILD_OPENCOG ] ; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -b ; fi ;;
-  min)   if [ $BUILD_OPENCOG ] ; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -b ; fi ;;
-  dev)   if [ $BUILD_OPENCOG ] ; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -b ; fi ;;
+local) if [ $BUILD_OPENCOG ]; then build_opencog; fi ;;
+demo) if [ $BUILD_OPENCOG ]; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -b; fi ;;
+min) if [ $BUILD_OPENCOG ]; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -b; fi ;;
+dev) if [ $BUILD_OPENCOG ]; then chroot $LIVE_SQUASH_UNION $PATH_PREFIX/bin/$TOOL_NAME $VERBOSE -b; fi ;;
 esac
 
 case $PACKAGE_TYPE in
-  min)	remove_dev_debs ; remove_doc_debs ; remove_source ; remove_build ;;
-  demo)	remove_dev_debs ; remove_doc_debs ; remove_source ; remove_build ;;
-  dev)	keep_source  ;;
+min)
+  remove_dev_debs
+  remove_doc_debs
+  remove_source
+  remove_build
+  ;;
+demo)
+  remove_dev_debs
+  remove_doc_debs
+  remove_source
+  remove_build
+  ;;
+dev) keep_source ;;
 esac
 
 case $PACKAGE_TYPE in
-  min)  prepare_live_iso ; write_live_media ;;
-  demo) prepare_live_iso ; write_live_media ;;
-  dev)  prepare_live_iso ; write_live_media ;;
+min)
+  prepare_live_iso
+  write_live_media
+  ;;
+demo)
+  prepare_live_iso
+  write_live_media
+  ;;
+dev)
+  prepare_live_iso
+  write_live_media
+  ;;
 esac

--- a/ocpkg
+++ b/ocpkg
@@ -631,7 +631,7 @@ install_opencog_github_repo() {
   cd /tmp/
   # cleaning up remnants from previous install failures, if any.
   rm -rf master.tar.gz* ${REPO}-master
-  wget https://github.com/singnet/${REPO}/archive/master.tar.gz
+  wget https://github.com/ntoxeg/${REPO}/archive/master.tar.gz
   tar -xvf master.tar.gz
   cd ${REPO}-master/
   mkdir build

--- a/ocpkg
+++ b/ocpkg
@@ -115,7 +115,6 @@ PACKAGES_FETCH="
 		git \
 		curl \
 		wget \
-    ca-certificates \
 			"
 #bzr-rewrite \
 
@@ -897,11 +896,17 @@ install_link_grammar() {
 
   cd /tmp/
   # cleaning up remnants from previous install failures, if any.
-  rm -rf link-grammar-5.*/
-
-  wget http://www.abisource.com/downloads/link-grammar/5.8.0/link-grammar-5.8.0.tar.gz
-  tar -zxf link-grammar-5*.tar.gz
-
+  # rm -rf link-grammar-5.*/
+  # if [ $# -eq 1 ]; then
+  #   wget http://www.abisource.com/downloads/link-grammar/${1}/link-grammar-${1}.tar.gz
+  #   tar -zxf link-grammar-5*.tar.gz
+  # else
+  #   wget -r --no-parent -nH --cut-dirs=2 \
+  #     http://www.abisource.com/downloads/link-grammar/current/
+  #   tar -zxf current/link-grammar-5*.tar.gz
+  #   rm -r current
+  # fi
+  tar -zxf link-grammar-5.*.tar.gz
   cd link-grammar-5.*/
   mkdir build
   cd build

--- a/ocpkg
+++ b/ocpkg
@@ -132,6 +132,7 @@ PACKAGES_BUILD=" build-essential \
 		libicu-dev \
 		libbz2-dev \
 		python3-dev \
+    python3-wheel \
 		python3-setuptools \
 		python3-nose \
 		libboost-date-time-dev \
@@ -191,7 +192,7 @@ PACKAGES_DOC="
 		libpango1.0-doc \
 		libgtk-3-doc \
 		texlive-latex-base-doc \
-		python-doc \
+		python3-doc \
 		devhelp-common \
 		texlive-doc-base \
 		doxygen \
@@ -720,7 +721,7 @@ cd /tmp
 
 # For sentiment analysis
 # TODO: update depending on https://github.com/opencog/opencog/issues/2285
-sudo pip3 install -U pyyaml nltk Flask flask-restful flask-restful-swagger flask-cors
+sudo python3 -m pip install -U pyyaml nltk Flask flask-restful flask-restful-swagger flask-cors
 sudo python3 -m nltk.downloader -d /usr/local/share/nltk_data punkt averaged_perceptron_tagger
 rm -f requirements.txt*
 cd $CURRENT_DIR


### PR DESCRIPTION
This is one of the three opened pull requests opened among OpenCog projects that changes and fixes a few scripts such that you can build and use OpenCog on the new LTS Ubuntu 20.04, coming out this April.

Unfortunately, there is a small fix that I had to apply to Cogutil, so these changes **are not** backward-compatible.

What changed here is that ocpkg can now use a `GITHUB_NAME` environment variable to select under what GitHub username it will look for OpenCog repositories - useful if somebody has their forks.

Again, this is not backwards-compatible so I'm just leaving this here in case some day you want to move to 20.04, so perhaps this will save you time.